### PR TITLE
Abstract out signing funding inputs to wallet

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Pin secp256k1-sys
+        run: cargo generate-lockfile --verbose && cargo update -p secp256k1-sys --precise "0.4.1" --verbose
       - name: Build
         run: cargo build --verbose
       - name: Test
@@ -26,7 +28,7 @@ jobs:
           key: test-cache-${{ github.run_id }}-${{ github.run_number }}
       - uses: actions/checkout@v2
       - id: set-matrix
-        run: cargo test --no-run && echo "::set-output name=matrix::$(scripts/get_test_list.sh execution manager)"
+        run: cargo generate-lockfile --verbose && cargo update -p secp256k1-sys --precise "0.4.1" --verbose && cargo test --no-run && echo "::set-output name=matrix::$(scripts/get_test_list.sh execution manager)"
   integration_tests:
     name: integration-tests
     needs: integration_tests_prepare
@@ -42,6 +44,8 @@ jobs:
         with:
           path: target/debug/deps
           key: test-cache-${{ github.run_id }}-${{ github.run_number }}
+      - name: Pin secp256k1-sys
+        run: cargo generate-lockfile --verbose && cargo update -p secp256k1-sys --precise "0.4.1" --verbose
       - name: Start bitcoin node
         run: ./scripts/start_node.sh
       - name: Wait for container to run

--- a/dlc-manager/src/lib.rs
+++ b/dlc-manager/src/lib.rs
@@ -71,8 +71,16 @@ pub trait Wallet {
     fn get_new_secret_key(&self) -> Result<SecretKey, Error>;
     /// Get the secret key associated with the provided public key.
     fn get_secret_key_for_pubkey(&self, pubkey: &PublicKey) -> Result<SecretKey, Error>;
-    /// Get the secret key associated with the provided address.
-    fn get_secret_key_for_address(&self, address: &Address) -> Result<SecretKey, Error>;
+
+    /// Signs a transaction input
+    fn sign_tx_input(
+        &self,
+        tx: &mut Transaction,
+        input_index: usize,
+        tx_out: &TxOut,
+        redeem_script: Option<Script>,
+    ) -> Result<(), Error>;
+
     /// Get a set of UTXOs to fund the given amount.
     fn get_utxos_for_amount(
         &self,


### PR DESCRIPTION
This is an attempt to try and abstract out the signing of the funding inputs to be agnostic to the wallet.
