### PR TITLE
Chore/rename left endpoint

### DIFF
--- a/dlc-manager/src/conversion_utils.rs
+++ b/dlc-manager/src/conversion_utils.rs
@@ -372,7 +372,7 @@ impl From<&PayoutFunction> for SerPayoutFunction {
                         ),
                     };
                     SerPayoutFunctionPiece {
-                        left_end_point: left,
+                        end_point: left,
                         payout_curve_piece: piece,
                     }
                 })
@@ -403,7 +403,7 @@ impl From<&SerPayoutFunction> for PayoutFunction {
                         .payout_function_pieces
                         .iter()
                         .skip(1)
-                        .map(|x| &x.left_end_point)
+                        .map(|x| &x.end_point)
                         .chain(vec![&payout_function.last_endpoint]),
                 )
                 .map(|(x, y)| from_ser_payout_function_piece(x, y))
@@ -419,7 +419,7 @@ fn from_ser_payout_function_piece(
     match &piece.payout_curve_piece {
         SerPayoutCurvePiece::PolynomialPayoutCurvePiece(p) => {
             PayoutFunctionPiece::PolynomialPayoutCurvePiece(PolynomialPayoutCurvePiece {
-                payout_points: vec![(&piece.left_end_point).into()]
+                payout_points: vec![(&piece.end_point).into()]
                     .into_iter()
                     .chain(p.payout_points.iter().map(|x| x.into()))
                     .chain(vec![(right_end_point).into()])
@@ -428,7 +428,7 @@ fn from_ser_payout_function_piece(
         }
         SerPayoutCurvePiece::HyperbolaPayoutCurvePiece(h) => {
             PayoutFunctionPiece::HyperbolaPayoutCurvePiece(HyperbolaPayoutCurvePiece {
-                left_end_point: (&piece.left_end_point).into(),
+                left_end_point: (&piece.end_point).into(),
                 right_end_point: right_end_point.into(),
                 use_positive_piece: h.use_positive_piece,
                 translate_outcome: h.translate_outcome,

--- a/dlc-messages/src/contract_msgs.rs
+++ b/dlc-messages/src/contract_msgs.rs
@@ -142,11 +142,11 @@ impl_dlc_writeable!(PayoutFunction, {(payout_function_pieces, vec), (last_endpoi
     serde(rename_all = "camelCase")
 )]
 pub struct PayoutFunctionPiece {
-    pub left_end_point: PayoutPoint,
+    pub end_point: PayoutPoint,
     pub payout_curve_piece: PayoutCurvePiece,
 }
 
-impl_dlc_writeable!(PayoutFunctionPiece, { (left_end_point, writeable), (payout_curve_piece, writeable) });
+impl_dlc_writeable!(PayoutFunctionPiece, { (end_point, writeable), (payout_curve_piece, writeable) });
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(

--- a/dlc-messages/src/test_inputs/offer_msg.json
+++ b/dlc-messages/src/test_inputs/offer_msg.json
@@ -12,7 +12,7 @@
             "payoutFunction": {
               "payoutFunctionPieces": [
                 {
-                  "leftEndPoint": {
+                  "endPoint": {
                     "eventOutcome": 0,
                     "outcomePayout": 0,
                     "extraPrecision": 0


### PR DESCRIPTION
Rename left_end_point to end_point in messaging so that test vectors have proper naming.