### PR TITLE
Update deps to latest versions

### DIFF
--- a/bitcoin-rpc-provider/Cargo.toml
+++ b/bitcoin-rpc-provider/Cargo.toml
@@ -5,10 +5,10 @@ name = "bitcoin-rpc-provider"
 version = "0.1.0"
 
 [dependencies]
-bitcoin = {version = "0.28"}
-bitcoincore-rpc = {version = "0.15.0"}
-bitcoincore-rpc-json = {version = "0.15.0"}
+bitcoin = {version = "0.29.2"}
+bitcoincore-rpc = {version = "0.16.0"}
+bitcoincore-rpc-json = {version = "0.16.0"}
 dlc-manager = {path = "../dlc-manager"}
-lightning = {version = "0.0.107"}
+lightning = {version = "0.0.112"}
 log = "0.4.14"
 rust-bitcoin-coin-selection = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection", features = ["rand"]}

--- a/bitcoin-test-utils/Cargo.toml
+++ b/bitcoin-test-utils/Cargo.toml
@@ -4,6 +4,6 @@ name = "bitcoin-test-utils"
 version = "0.1.0"
 
 [dependencies]
-bitcoin = {version = "0.28"}
-bitcoincore-rpc = {version = "0.15"}
-bitcoincore-rpc-json = {version = "0.15"}
+bitcoin = {version = "0.29.2"}
+bitcoincore-rpc = {version = "0.16"}
+bitcoincore-rpc-json = {version = "0.16"}

--- a/bitcoin-test-utils/src/lib.rs
+++ b/bitcoin-test-utils/src/lib.rs
@@ -63,5 +63,5 @@ pub fn tx_to_string(tx: &Transaction) -> String {
 /// Panics if given invalid hex or data.
 pub fn tx_from_string(tx_str: &str) -> Transaction {
     let tx_hex = str_to_hex(tx_str);
-    Transaction::consensus_decode(&tx_hex[..]).unwrap()
+    Transaction::consensus_decode(&mut tx_hex.as_slice()).unwrap()
 }

--- a/dlc-manager/Cargo.toml
+++ b/dlc-manager/Cargo.toml
@@ -15,27 +15,27 @@ use-serde = ["serde", "dlc/use-serde", "dlc-messages/serde", "dlc-trie/use-serde
 
 [dependencies]
 async-trait = "0.1.50"
-bitcoin = {version = "0.28"}
+bitcoin = {version = "0.29.2" }
 dlc = {version = "0.3.0", path = "../dlc"}
 dlc-messages = {version = "0.3.0", path = "../dlc-messages"}
 dlc-trie = {version = "0.3.0", path = "../dlc-trie"}
-lightning = {version = "0.0.107"}
+lightning = {version = "0.0.112" }
 log = "0.4.14"
 rand_chacha = {version = "0.3.1", optional = true}
-secp256k1-zkp = {version = "0.6.0", features = ["bitcoin_hashes", "rand", "rand-std"]}
+secp256k1-zkp = {version = "0.7.0", features = ["bitcoin_hashes", "rand", "rand-std"]}
 serde = {version = "1.0", optional = true}
 
 [dev-dependencies]
 bitcoin-rpc-provider = {path = "../bitcoin-rpc-provider"}
 bitcoin-test-utils = {path = "../bitcoin-test-utils"}
-bitcoincore-rpc = {version = "0.15"}
-bitcoincore-rpc-json = {version = "0.15"}
-criterion = "0.3"
+bitcoincore-rpc = {version = "0.16.0" }
+bitcoincore-rpc-json = {version = "0.16.0" }
+criterion = "0.4.0"
 dlc-manager = {path = ".", features = ["use-serde"]}
 dlc-messages = {path = "../dlc-messages", features = ["serde"]}
-env_logger = "0.8.4"
+env_logger = "0.9.1"
 mocks = {path = "../mocks"}
-secp256k1-zkp = {version = "0.6.0", features = ["bitcoin_hashes", "rand", "rand-std", "global-context", "use-serde"]}
+secp256k1-zkp = {version = "0.7.0", features = ["bitcoin_hashes", "rand", "rand-std", "global-context", "use-serde"]}
 serde = "1.0"
 serde_json = "1.0"
 

--- a/dlc-manager/src/channel_updater.rs
+++ b/dlc-manager/src/channel_updater.rs
@@ -22,7 +22,7 @@ use crate::{
     utils::get_new_temporary_id,
     Signer, Time, Wallet,
 };
-use bitcoin::{OutPoint, Script, Transaction, TxIn, Witness};
+use bitcoin::{OutPoint, Script, Sequence, Transaction, TxIn, Witness};
 use dlc::{
     channel::{get_tx_adaptor_signature, verify_tx_adaptor_signature, DlcChannelTransactions},
     PartyParams,
@@ -188,7 +188,7 @@ where
         0,
         offered_contract.contract_maturity_bound,
         offered_contract.fund_output_serial_id,
-        offered_channel.cet_nsequence,
+        Sequence(offered_channel.cet_nsequence),
     )?;
 
     let own_base_secret_key = wallet.get_secret_key_for_pubkey(&accept_points.own_basepoint)?;
@@ -324,7 +324,7 @@ where
         0,
         offered_contract.contract_maturity_bound,
         offered_contract.fund_output_serial_id,
-        cet_nsequence,
+        Sequence(cet_nsequence),
     )?;
 
     let channel_id = crate::utils::compute_id(
@@ -1122,7 +1122,7 @@ where
         offered_contract.contract_timeout,
         offered_contract.fee_rate_per_vb,
         0,
-        cet_nsequence,
+        Sequence(cet_nsequence),
     )?;
 
     let buffer_adaptor_signature = get_tx_adaptor_signature(
@@ -1232,7 +1232,7 @@ where
         offered_contract.contract_timeout,
         offered_contract.fee_rate_per_vb,
         0,
-        cet_nsequence,
+        Sequence(cet_nsequence),
     )?;
 
     let offer_own_sk = derive_private_key(secp, &offer_per_update_point, &own_base_secret_key)?;
@@ -1652,7 +1652,7 @@ fn get_settle_tx_and_adaptor_sig(
             vout: fund_vout as u32,
         },
         script_sig: Script::new(),
-        sequence: 0xffffffff,
+        sequence: Sequence::MAX,
         witness: Witness::default(),
     };
 

--- a/dlc-manager/src/contract_updater.rs
+++ b/dlc-manager/src/contract_updater.rs
@@ -409,11 +409,12 @@ where
                         x.funding_input.input_serial_id
                     ))
                 })?;
-            let tx = Transaction::consensus_decode(&*x.funding_input.prev_tx).map_err(|_| {
-                Error::InvalidParameters(
-                    "Could not decode funding input previous tx parameter".to_string(),
-                )
-            })?;
+            let tx = Transaction::consensus_decode(&mut x.funding_input.prev_tx.as_slice())
+                .map_err(|_| {
+                    Error::InvalidParameters(
+                        "Could not decode funding input previous tx parameter".to_string(),
+                    )
+                })?;
             let vout = x.funding_input.prev_tx_vout;
             let tx_out = tx.output.get(vout as usize).ok_or_else(|| {
                 Error::InvalidParameters(format!("Previous tx output not found at index {}", vout))
@@ -603,12 +604,13 @@ where
                     funding_input_info.funding_input.input_serial_id,
                 ))
             })?;
-        let tx = Transaction::consensus_decode(&*funding_input_info.funding_input.prev_tx)
-            .map_err(|_| {
-                Error::InvalidParameters(
-                    "Could not decode funding input previous tx parameter".to_string(),
-                )
-            })?;
+        let tx =
+            Transaction::consensus_decode(&mut funding_input_info.funding_input.prev_tx.as_slice())
+                .map_err(|_| {
+                    Error::InvalidParameters(
+                        "Could not decode funding input previous tx parameter".to_string(),
+                    )
+                })?;
         let vout = funding_input_info.funding_input.prev_tx_vout;
         let tx_out = tx.output.get(vout as usize).ok_or_else(|| {
             Error::InvalidParameters(format!("Previous tx output not found at index {}", vout))

--- a/dlc-manager/src/conversion_utils.rs
+++ b/dlc-manager/src/conversion_utils.rs
@@ -75,7 +75,7 @@ pub fn get_tx_input_infos(
     let mut inputs = Vec::new();
 
     for fund_input in funding_inputs {
-        let tx = Transaction::consensus_decode(&*fund_input.prev_tx)?;
+        let tx = Transaction::consensus_decode(&mut fund_input.prev_tx.as_slice())?;
         let vout = fund_input.prev_tx_vout;
         let tx_out = tx
             .output

--- a/dlc-manager/src/lib.rs
+++ b/dlc-manager/src/lib.rs
@@ -17,6 +17,7 @@ extern crate bitcoin;
 extern crate dlc;
 #[macro_use]
 extern crate dlc_messages;
+extern crate core;
 extern crate dlc_trie;
 extern crate lightning;
 extern crate log;

--- a/dlc-manager/src/manager.rs
+++ b/dlc-manager/src/manager.rs
@@ -644,7 +644,12 @@ where
 
     fn check_refund(&mut self, contract: &SignedContract) -> Result<(), Error> {
         // TODO(tibo): should check for confirmation of refund before updating state
-        if contract.accepted_contract.dlc_transactions.refund.lock_time as u64
+        if contract
+            .accepted_contract
+            .dlc_transactions
+            .refund
+            .lock_time
+            .0 as u64
             <= self.time.unix_time_now()
         {
             let accepted_contract = &contract.accepted_contract;

--- a/dlc-messages/Cargo.toml
+++ b/dlc-messages/Cargo.toml
@@ -8,19 +8,19 @@ repository = "https://github.com/p2pderivatives/rust-dlc/tree/master/dlc-message
 version = "0.3.0"
 
 [features]
-use-serde = ["serde", "bitcoin/use-serde", "secp256k1-zkp/use-serde"]
+use-serde = ["serde", "secp256k1-zkp/use-serde"]
 
 [dependencies]
-bitcoin = {version = "0.28"}
+bitcoin = {version = "0.29.2"}
 dlc = {version = "0.3.0", path = "../dlc"}
-lightning = {version = "0.0.107"}
-secp256k1-zkp = {version = "0.6.0", features = ["bitcoin_hashes", "rand", "rand-std"]}
+lightning = {version = "0.0.112" }
+secp256k1-zkp = {version = "0.7.0", features = ["bitcoin_hashes", "rand", "rand-std"]}
 serde = {version = "1.0", features = ["derive"], optional = true}
 
 [dev-dependencies]
-bitcoin = {version = "0.28", features = ["use-serde"]}
+bitcoin = {version = "0.29.2"}
 bitcoin-test-utils = {path = "../bitcoin-test-utils"}
 dlc-messages = {path = "./", features = ["use-serde"]}
-secp256k1-zkp = {version = "0.6.0", features = ["use-serde", "global-context"]}
+secp256k1-zkp = {version = "0.7.0", features = ["use-serde", "global-context"]}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"

--- a/dlc-messages/src/lib.rs
+++ b/dlc-messages/src/lib.rs
@@ -130,7 +130,7 @@ impl From<&FundingInput> for TxInputInfo {
     fn from(funding_input: &FundingInput) -> TxInputInfo {
         TxInputInfo {
             outpoint: OutPoint {
-                txid: Transaction::consensus_decode(&funding_input.prev_tx[..])
+                txid: Transaction::consensus_decode(&mut funding_input.prev_tx.as_slice())
                     .expect("Transaction Decode Error")
                     .txid(),
                 vout: funding_input.prev_tx_vout,

--- a/dlc-messages/src/oracle_msgs.rs
+++ b/dlc-messages/src/oracle_msgs.rs
@@ -350,7 +350,7 @@ mod tests {
 
     fn some_schnorr_pubkey() -> XOnlyPublicKey {
         let key_pair = KeyPair::new(SECP256K1, &mut thread_rng());
-        XOnlyPublicKey::from_keypair(&key_pair)
+        XOnlyPublicKey::from_keypair(&key_pair).0
     }
 
     fn digit_event(nb_nonces: usize) -> OracleEvent {
@@ -374,7 +374,7 @@ mod tests {
     #[test]
     fn valid_oracle_announcement_passes_validation_test() {
         let key_pair = KeyPair::new(SECP256K1, &mut thread_rng());
-        let oracle_pubkey = XOnlyPublicKey::from_keypair(&key_pair);
+        let oracle_pubkey = XOnlyPublicKey::from_keypair(&key_pair).0;
         let events = [digit_event(10), enum_event(1)];
         for event in events {
             let mut event_hex = Vec::new();
@@ -398,7 +398,7 @@ mod tests {
     #[test]
     fn invalid_oracle_announcement_fails_validation_test() {
         let key_pair = KeyPair::new(SECP256K1, &mut thread_rng());
-        let oracle_pubkey = XOnlyPublicKey::from_keypair(&key_pair);
+        let oracle_pubkey = XOnlyPublicKey::from_keypair(&key_pair).0;
         let events = [digit_event(9), enum_event(2)];
         for event in events {
             let mut event_hex = Vec::new();
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn invalid_oracle_announcement_signature_fails_validation_test() {
         let key_pair = KeyPair::new(SECP256K1, &mut thread_rng());
-        let oracle_pubkey = XOnlyPublicKey::from_keypair(&key_pair);
+        let oracle_pubkey = XOnlyPublicKey::from_keypair(&key_pair).0;
         let event = digit_event(10);
         let mut event_hex = Vec::new();
         event

--- a/dlc-trie/Cargo.toml
+++ b/dlc-trie/Cargo.toml
@@ -12,8 +12,8 @@ parallel = ["rayon"]
 use-serde = ["serde", "dlc/use-serde"]
 
 [dependencies]
-bitcoin = {version = "0.28"}
+bitcoin = {version = "0.29.2" }
 dlc = {version = "0.3.0", path = "../dlc"}
 rayon = {version = "1.5", optional = true}
-secp256k1-zkp = {version = "0.6.0"}
+secp256k1-zkp = {version = "0.7.0" }
 serde = {version = "1.0", optional = true, default_features = false, features = ["derive"]}

--- a/dlc/Cargo.toml
+++ b/dlc/Cargo.toml
@@ -8,22 +8,22 @@ repository = "https://github.com/p2pderivatives/rust-dlc/tree/master/dlc"
 version = "0.3.0"
 
 [dependencies]
-bitcoin = {version = "0.28"}
-miniscript = "7.0.0"
-secp256k1-sys = {version = "0.5.2"}
-secp256k1-zkp = {version = "0.6.0", features = ["bitcoin_hashes", "rand-std"]}
+bitcoin = {version = "0.29.2"}
+miniscript = "8.0.0"
+secp256k1-sys = {version = "0.6.1" }
+secp256k1-zkp = {version = "0.7.0", features = ["bitcoin_hashes", "rand-std"]}
 serde = {version = "1.0", default-features = false, optional = true}
 
 [features]
 # for benchmarks
 unstable = []
-use-serde = ["serde", "bitcoin/use-serde", "secp256k1-zkp/use-serde"]
+use-serde = ["serde", "secp256k1-zkp/use-serde"]
 
 [dev-dependencies]
-bitcoin = {version = "0.28", features = ["use-serde"]}
+bitcoin = {version = "0.29.2"}
 bitcoin-test-utils = {path = "../bitcoin-test-utils"}
-bitcoincore-rpc = {version = "0.15.0"}
-bitcoincore-rpc-json = {version = "0.15.0"}
+bitcoincore-rpc = {version = "0.16.0" }
+bitcoincore-rpc-json = {version = "0.16.0" }
 dlc-trie = {path = "../dlc-trie"}
 rayon = "1.5"
-secp256k1-zkp = {version = "0.6.0", features = ["bitcoin_hashes", "rand", "rand-std", "serde", "global-context"]}
+secp256k1-zkp = {version = "0.7.0", features = ["bitcoin_hashes", "rand", "rand-std", "serde", "global-context"]}

--- a/dlc/src/util.rs
+++ b/dlc/src/util.rs
@@ -1,21 +1,21 @@
 //! Utility functions not uniquely related to DLC
 
 use bitcoin::util::sighash::SighashCache;
-use bitcoin::Witness;
 use bitcoin::{
     blockdata::script::Builder, hash_types::PubkeyHash, util::address::Payload, EcdsaSighashType,
     Script, Transaction, TxOut,
 };
+use bitcoin::{Sequence, Witness};
 use secp256k1_zkp::{ecdsa::Signature, Message, PublicKey, Secp256k1, SecretKey, Signing};
 
 use crate::Error;
 
 // Setting the nSequence for every input of a transaction to this value disables
 // both RBF and nLockTime usage.
-pub(crate) const DISABLE_LOCKTIME: u32 = 0xffffffff;
+pub(crate) const DISABLE_LOCKTIME: Sequence = Sequence(0xffffffff);
 // Setting the nSequence for every input of a transaction to this value disables
 // RBF but enables nLockTime usage.
-pub(crate) const ENABLE_LOCKTIME: u32 = 0xfffffffe;
+pub(crate) const ENABLE_LOCKTIME: Sequence = Sequence(0xfffffffe);
 
 /// Get a BIP143 (https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki)
 /// signature hash with sighash all flag for a segwit transaction input as
@@ -222,7 +222,7 @@ pub(crate) fn discard_dust(txs: Vec<TxOut>, dust_limit: u64) -> Vec<TxOut> {
     txs.into_iter().filter(|x| x.value >= dust_limit).collect()
 }
 
-pub(crate) fn get_sequence(lock_time: u32) -> u32 {
+pub(crate) fn get_sequence(lock_time: u32) -> Sequence {
     if lock_time == 0 {
         DISABLE_LOCKTIME
     } else {

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 dlc-messages = {path = "../dlc-messages"}
 honggfuzz = "0.5"
-lightning = {version = "0.0.106"}
+lightning = {version = "0.0.112" }
 
 [workspace]
 members = ["."]

--- a/mocks/Cargo.toml
+++ b/mocks/Cargo.toml
@@ -7,6 +7,6 @@ version = "0.1.0"
 [dependencies]
 dlc = {path = "../dlc"}
 dlc-manager = {path = "../dlc-manager"}
-dlc-messages = {path = "../dlc-messages"}
-lightning = {version = "0.0.107"}
-secp256k1-zkp = {version = "0.6.0", features = ["bitcoin_hashes", "rand", "rand-std"]}
+dlc-messages = {version = "0.3.0", path = "../dlc-messages"}
+lightning = {version = "0.0.112" }
+secp256k1-zkp = {version = "0.7.0", features = ["bitcoin_hashes", "rand", "rand-std"]}

--- a/mocks/src/mock_oracle_provider.rs
+++ b/mocks/src/mock_oracle_provider.rs
@@ -36,7 +36,7 @@ impl MockOracle {
 
     pub fn from_secret_key(sk: &SecretKey) -> Self {
         let secp = Secp256k1::new();
-        let key_pair = KeyPair::from_secret_key(&secp, *sk);
+        let key_pair = KeyPair::from_secret_key(&secp, sk);
 
         MockOracle {
             secp,
@@ -56,7 +56,7 @@ impl Default for MockOracle {
 
 impl Oracle for MockOracle {
     fn get_public_key(&self) -> XOnlyPublicKey {
-        XOnlyPublicKey::from_keypair(&self.key_pair)
+        XOnlyPublicKey::from_keypair(&self.key_pair).0
     }
 
     fn get_announcement(&self, event_id: &str) -> Result<OracleAnnouncement, DaemonError> {
@@ -95,7 +95,10 @@ impl MockOracle {
             .map(|x| KeyPair::from_seckey_slice(&self.secp, x.as_ref()).unwrap())
             .collect();
 
-        let nonces = key_pairs.iter().map(XOnlyPublicKey::from_keypair).collect();
+        let nonces = key_pairs
+            .iter()
+            .map(|k| XOnlyPublicKey::from_keypair(k).0)
+            .collect();
 
         self.nonces.insert(event_id.to_string(), priv_nonces);
 

--- a/p2pd-oracle-client/Cargo.toml
+++ b/p2pd-oracle-client/Cargo.toml
@@ -12,8 +12,8 @@ chrono = {version = "0.4.19", features = ["serde"]}
 dlc-manager = {path = "../dlc-manager"}
 dlc-messages = {path = "../dlc-messages", features = ["use-serde"]}
 reqwest = {version = "0.11", features = ["blocking", "json"]}
-secp256k1-zkp = {version = "0.6.0"}
+secp256k1-zkp = {version = "0.7.0" }
 serde = {version = "*", features = ["derive"]}
 
 [dev-dependencies]
-mockito = "0.30.0"
+mockito = "0.31.0"

--- a/sample/Cargo.toml
+++ b/sample/Cargo.toml
@@ -5,18 +5,18 @@ name = "sample"
 version = "0.1.0"
 
 [dependencies]
-bitcoin = {version = "0.28"}
+bitcoin = {version = "0.29.2"}
 bitcoin-rpc-provider = {path = "../bitcoin-rpc-provider"}
 dlc = {path = "../dlc", features = ["use-serde"]}
 dlc-manager = {path = "../dlc-manager", features = ["use-serde", "parallel"]}
 dlc-messages = {path = "../dlc-messages"}
 dlc-sled-storage-provider = {path = "../dlc-sled-storage-provider"}
 futures = "0.3"
-lightning = {version = "0.0.107"}
-lightning-net-tokio = {version = "0.0.107"}
+lightning = {version = "0.0.112"}
+lightning-net-tokio = {version = "0.0.112" }
 p2pd-oracle-client = {path = "../p2pd-oracle-client"}
 serde = "1.0"
 serde_json = "1.0"
-serde_yaml = "0.8"
-time = "0.2"
+serde_yaml = "0.9.14"
+time = "0.3.16"
 tokio = {version = "1.5", features = ["io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time"]}

--- a/sample/src/disk.rs
+++ b/sample/src/disk.rs
@@ -20,7 +20,7 @@ impl Logger for FilesystemLogger {
         let raw_log = record.args.to_string();
         let log = format!(
             "{} {:<5} [{}:{}] {}\n",
-            OffsetDateTime::now_utc().format("%F %T"),
+            OffsetDateTime::now_utc().unix_timestamp(),
             record.level,
             record.module_path,
             record.line,


### PR DESCRIPTION
There are some descriptors tests failing in the `dlc` crate, not sure why seems like it is from updating the descriptor dependency. Otherwise this is essentially a remake of #74 on top of #65

Note: this PR will need to be merged and the `rust-bitcoin-coin-selection` dep and be changed back to point to the `p2pderivatives` repo