### PR TITLE
Update `std::error::Error` implementations

### DIFF
--- a/bitcoin-rpc-provider/src/lib.rs
+++ b/bitcoin-rpc-provider/src/lib.rs
@@ -68,7 +68,7 @@ impl From<EncodeError> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::RpcError(e) => write!(f, "Bitcoin Rpc Error {}", e),
+            Error::RpcError(_) => write!(f, "Bitcoin Rpc Error"),
             Error::NotEnoughCoins => {
                 write!(f, "Utxo pool did not contain enough coins to reach target.")
             }

--- a/bitcoin-rpc-provider/src/lib.rs
+++ b/bitcoin-rpc-provider/src/lib.rs
@@ -79,11 +79,7 @@ impl std::fmt::Display for Error {
 }
 
 impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        "bitcoincore-rpc-provider error"
-    }
-
-    fn cause(&self) -> Option<&dyn std::error::Error> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             Error::RpcError(ref e) => Some(e),
             _ => None,

--- a/dlc-manager/src/conversion_utils.rs
+++ b/dlc-manager/src/conversion_utils.rs
@@ -48,11 +48,12 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::BitcoinEncoding(ref e) => write!(f, "Invalid encoding {}", e),
+            Error::BitcoinEncoding(_) => write!(f, "Invalid encoding"),
             Error::InvalidParameters => write!(f, "Invalid parameters."),
         }
     }
 }
+
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {

--- a/dlc-manager/src/error.rs
+++ b/dlc-manager/src/error.rs
@@ -30,16 +30,16 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Conversion(ref e) => write!(f, "Conversion error {}", e),
-            Error::IOError(ref e) => write!(f, "IO error {}", e),
+            Error::Conversion(_) => write!(f, "Conversion error"),
+            Error::IOError(_) => write!(f, "IO error"),
             Error::InvalidState(ref s) => write!(f, "Invalid state: {}", s),
             Error::InvalidParameters(ref s) => write!(f, "Invalid parameters were provided: {}", s),
             Error::WalletError(ref e) => write!(f, "Wallet error {}", e),
             Error::BlockchainError(ref s) => write!(f, "Blockchain error {}", s),
             Error::StorageError(ref s) => write!(f, "Storage error {}", s),
-            Error::DlcError(ref e) => write!(f, "Dlc error {}", e),
+            Error::DlcError(_) => write!(f, "Dlc error"),
             Error::OracleError(ref s) => write!(f, "Oracle error {}", s),
-            Error::SecpError(ref s) => write!(f, "Secp error {}", s),
+            Error::SecpError(_) => write!(f, "Secp error"),
         }
     }
 }
@@ -71,5 +71,22 @@ impl From<secp256k1_zkp::Error> for Error {
 impl From<secp256k1_zkp::UpstreamError> for Error {
     fn from(e: secp256k1_zkp::UpstreamError) -> Error {
         Error::SecpError(secp256k1_zkp::Error::Upstream(e))
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Conversion(e) => Some(e),
+            Error::IOError(e) => Some(e),
+            Error::InvalidParameters(_) => None,
+            Error::InvalidState(_) => None,
+            Error::WalletError(_) => None,
+            Error::BlockchainError(_) => None,
+            Error::StorageError(_) => None,
+            Error::OracleError(_) => None,
+            Error::DlcError(e) => Some(e),
+            Error::SecpError(e) => Some(e),
+        }
     }
 }

--- a/dlc-manager/src/manager.rs
+++ b/dlc-manager/src/manager.rs
@@ -2222,15 +2222,7 @@ mod test {
 
         mocks::mock_time::set_time(0);
 
-        Manager::new(
-            wallet,
-            blockchain.clone(),
-            store.clone(),
-            oracles,
-            time,
-            blockchain.clone(),
-        )
-        .unwrap()
+        Manager::new(wallet, blockchain.clone(), store, oracles, time, blockchain).unwrap()
     }
 
     fn pubkey() -> PublicKey {

--- a/dlc-messages/src/lib.rs
+++ b/dlc-messages/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
         let mut single_contract_input = offer.clone();
         single_contract_input.contract_info =
             if let ContractInfo::DisjointContractInfo(d) = offer.contract_info {
-                let mut single = d.clone();
+                let mut single = d;
                 single.contract_infos.remove(1);
                 ContractInfo::DisjointContractInfo(single)
             } else {

--- a/dlc-messages/src/segmentation/segment_reader.rs
+++ b/dlc-messages/src/segmentation/segment_reader.rs
@@ -26,6 +26,15 @@ impl std::fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::InvalidState(_) => None,
+            Error::InvalidParameter(_) => None,
+        }
+    }
+}
+
 impl Default for SegmentReader {
     fn default() -> Self {
         Self::new()

--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -214,10 +214,21 @@ impl From<miniscript::Error> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Secp256k1(ref e) => write!(f, "Secp256k1 error {}", e),
+            Error::Secp256k1(_) => write!(f, "Secp256k1 error"),
             Error::InvalidArgument => write!(f, "Invalid argument"),
-            Error::Sighash(ref e) => write!(f, "Error while computing sighash {}", e),
-            Error::Miniscript(ref e) => write!(f, "Error within miniscript {}", e),
+            Error::Sighash(_) => write!(f, "Error while computing sighash"),
+            Error::Miniscript(_) => write!(f, "Error within miniscript"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Secp256k1(e) => Some(e),
+            Error::Sighash(e) => Some(e),
+            Error::InvalidArgument => None,
+            Error::Miniscript(e) => Some(e),
         }
     }
 }

--- a/simple-wallet/src/lib.rs
+++ b/simple-wallet/src/lib.rs
@@ -275,8 +275,7 @@ mod tests {
     fn get_wallet() -> SimpleWallet<Rc<MockBlockchain>, Rc<MemoryStorage>> {
         let blockchain = Rc::new(MockBlockchain {});
         let storage = Rc::new(MemoryStorage::new());
-        let wallet = SimpleWallet::new(blockchain, storage, bitcoin::Network::Regtest);
-        wallet
+        SimpleWallet::new(blockchain, storage, bitcoin::Network::Regtest)
     }
 
     #[test]


### PR DESCRIPTION
My main motivation is to make `rust-dlc` work better with `anyhow`, but I cleaned up some minor things along the way.