### PR TITLE
Add more trait bounds to `dlc_manager::Error::WalletError`

### DIFF
--- a/dlc-manager/src/error.rs
+++ b/dlc-manager/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     /// An invalid state was encounter, likely to indicate a bug.
     InvalidState(String),
     /// An error occurred in the wallet component.
-    WalletError(Box<dyn std::error::Error>),
+    WalletError(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// An error occurred in the blockchain component.
     BlockchainError(String),
     /// The storage component encountered an error.


### PR DESCRIPTION
This ensures that the `dlc_manager::Error` enum can be used with `anyhow`.