### PR TITLE
Feature/ln dlc channels debug

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,6 +58,6 @@ jobs:
       - name: Wait for electrs to be ready
         run: ./scripts/wait_for_electrs.sh
       - name: Run test
-        run: RUST_BACKTRACE=1 ${{ matrix.tests }} --ignored
+        run: RUST_BACKTRACE=1 ${{ matrix.tests }} --ignored --exact
       - name: Stop bitcoin node
         run: ./scripts/stop_node.sh

--- a/dlc-manager/src/sub_channel_manager.rs
+++ b/dlc-manager/src/sub_channel_manager.rs
@@ -1969,11 +1969,10 @@ where
                     .expect("to have a per split seed"),
             )?;
 
-        let per_split_secret = derive_private_key(
-            self.dlc_channel_manager.get_secp(),
-            &state.signed_subchannel.own_per_split_point,
-            &per_split_seed,
-        );
+        let per_split_secret = SecretKey::from_slice(&build_commitment_secret(
+            per_split_seed.as_ref(),
+            sub_channel.update_idx,
+        ))?;
 
         let finalize = SubChannelCloseFinalize {
             channel_id: confirm.channel_id,

--- a/dlc-manager/tests/channel_execution_tests.rs
+++ b/dlc-manager/tests/channel_execution_tests.rs
@@ -545,7 +545,7 @@ fn channel_execution_test(test_params: TestParams, path: TestPath) {
                         first_send,
                         second,
                         channel_id,
-                        &second_receive,
+                        second_receive,
                         &generate_blocks,
                     );
                 }
@@ -615,10 +615,10 @@ fn channel_execution_test(test_params: TestParams, path: TestPath) {
                         settle_channel(
                             first.clone(),
                             first_send,
-                            first_receive.clone(),
+                            first_receive,
                             second.clone(),
                             second_send,
-                            second_receive.clone(),
+                            second_receive,
                             channel_id,
                         );
                     }

--- a/dlc-manager/tests/ln_dlc_channel_execution_tests.rs
+++ b/dlc-manager/tests/ln_dlc_channel_execution_tests.rs
@@ -926,7 +926,7 @@ fn ln_dlc_test(test_path: TestPath) {
             return;
         }
 
-        off_chain_close_finalize(&test_params, &alice_node, &bob_node, channel_id);
+        off_chain_close_finalize(&alice_node, &bob_node, channel_id);
 
         if let TestPath::OffChainCloseOpenClose = test_path {
             offer_sub_channel(
@@ -939,7 +939,7 @@ fn ln_dlc_test(test_path: TestPath) {
                 bob_descriptor.clone(),
             );
             off_chain_close_offer(&test_params, &alice_node, &bob_node, channel_id);
-            off_chain_close_finalize(&test_params, &alice_node, &bob_node, channel_id);
+            off_chain_close_finalize(&alice_node, &bob_node, channel_id);
         }
 
         offer_sub_channel(
@@ -1444,12 +1444,7 @@ fn offer_sub_channel(
     assert_sub_channel_state!(alice_node.sub_channel_manager, channel_id, Confirmed);
 
     if let TestPath::Reconnect = test_path {
-        reconnect(
-            alice_node,
-            bob_node,
-            alice_descriptor.clone(),
-            bob_descriptor.clone(),
-        );
+        reconnect(alice_node, bob_node, alice_descriptor, bob_descriptor);
 
         // For some weird reason uncommenting this triggers a stack overflow...
         // assert_sub_channel_state!(alice_node.sub_channel_manager, channel_id, Confirmed);
@@ -1580,8 +1575,7 @@ fn off_chain_close_offer(
         .unwrap();
 
     let dlc_channel_id = sub_channel.get_dlc_channel_id(0).unwrap();
-    let contract_id =
-        assert_channel_contract_state!(alice_node.dlc_manager, dlc_channel_id, Confirmed);
+    assert_channel_contract_state!(alice_node.dlc_manager, dlc_channel_id, Confirmed);
 
     let (close_offer, _) = alice_node
         .sub_channel_manager
@@ -1597,12 +1591,7 @@ fn off_chain_close_offer(
         .unwrap();
 }
 
-fn off_chain_close_finalize(
-    test_params: &TestParams,
-    alice_node: &LnDlcParty,
-    bob_node: &LnDlcParty,
-    channel_id: ChannelId,
-) {
+fn off_chain_close_finalize(alice_node: &LnDlcParty, bob_node: &LnDlcParty, channel_id: ChannelId) {
     let sub_channel = alice_node
         .dlc_manager
         .get_store()

--- a/dlc-manager/tests/ln_dlc_channel_execution_tests.rs
+++ b/dlc-manager/tests/ln_dlc_channel_execution_tests.rs
@@ -895,7 +895,11 @@ fn ln_dlc_test(test_path: TestPath) {
 
     mocks::mock_time::set_time(EVENT_MATURITY as u64);
 
-    if let TestPath::OffChainClosed | TestPath::SplitCheat | TestPath::CloseRejected = test_path {
+    if let TestPath::OffChainClosed
+    | TestPath::SplitCheat
+    | TestPath::CloseRejected
+    | TestPath::OffChainCloseOpenClose = test_path
+    {
         if let TestPath::SplitCheat = test_path {
             alice_node.dlc_manager.get_store().save();
         }

--- a/dlc-sled-storage-provider/src/lib.rs
+++ b/dlc-sled-storage-provider/src/lib.rs
@@ -1164,7 +1164,7 @@ mod tests {
     });
 
     sled_test!(get_empty_actions_test, |storage: SledStorageProvider| {
-        storage.save_sub_channel_actions(&vec![]).unwrap();
+        storage.save_sub_channel_actions(&[]).unwrap();
         let actions = storage
             .get_sub_channel_actions()
             .expect("Error getting sub channel actions");


### PR DESCRIPTION
The path where the multiple DLCs are being created was not actually called in the test `ln_dlc_off_chain_close_open_close`.

Once we call them the test fails with:

```
...


From Bob: 2023-04-21 20:24:12.843 DEBUG [lightning::chain::chainmonitor:708] Persistence of ChannelMonitorUpdate for channel c7346e546f15e1af92bf42305bbfaa8b287c32871954b448854eb1df785f59ca completed

thread 'ln_dlc_off_chain_close_open_close' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidParameters("Invalid split revocation secret")', dlc-manager/tests/ln_dlc_channel_execution_tests.rs:1669:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test ln_dlc_off_chain_close_open_close ... FAILED

failures:

failures:
    ln_dlc_off_chain_close_open_close

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 11 filtered out; finished in 17.65s
```