### PR TITLE
Add global-context flag on secp256k1 on mocks

### DIFF
--- a/mocks/Cargo.toml
+++ b/mocks/Cargo.toml
@@ -10,5 +10,5 @@ dlc = {path = "../dlc"}
 dlc-manager = {path = "../dlc-manager"}
 dlc-messages = {path = "../dlc-messages"}
 lightning = {version = "0.0.113"}
-secp256k1-zkp = {version = "0.7.0", features = ["bitcoin_hashes", "rand", "rand-std"]}
+secp256k1-zkp = {version = "0.7.0", features = ["bitcoin_hashes", "global-context", "rand", "rand-std"]}
 simple-wallet = {path = "../simple-wallet"}


### PR DESCRIPTION
global-context flag is needed on the secp256k1 package to compile this mocks package on it's own. Was inheriting from other imports when compiling the whole repo