### PR TITLE
Flush sled tree on upsert channel and sub_channel

### DIFF
--- a/dlc-manager/src/error.rs
+++ b/dlc-manager/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     /// An invalid state was encounter, likely to indicate a bug.
     InvalidState(String),
     /// An error occurred in the wallet component.
-    WalletError(Box<dyn std::error::Error>),
+    WalletError(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// An error occurred in the blockchain component.
     BlockchainError(String),
     /// The storage component encountered an error.

--- a/dlc-sled-storage-provider/src/lib.rs
+++ b/dlc-sled-storage-provider/src/lib.rs
@@ -361,6 +361,8 @@ impl Storage for SledStorageProvider {
                 },
             )
         .map_err(to_storage_error)?;
+
+        channel_tree.flush().map_err(|e| Error::StorageError(e.to_string()))?;
         Ok(())
     }
 
@@ -435,6 +437,8 @@ impl Storage for SledStorageProvider {
         self.sub_channel_tree()?
             .insert(subchannel.channel_id, serialized)
             .map_err(to_storage_error)?;
+
+        self.sub_channel_tree()?.flush().map_err(|e| Error::StorageError(e.to_string()))?;
         Ok(())
     }
 


### PR DESCRIPTION
We needed this as otherwise we'd run into invalid states after restarting the LDK node.