### PR TITLE
Flush sled tree on upsert channel and sub_channel

### DIFF
--- a/dlc-sled-storage-provider/src/lib.rs
+++ b/dlc-sled-storage-provider/src/lib.rs
@@ -361,6 +361,8 @@ impl Storage for SledStorageProvider {
                 },
             )
         .map_err(to_storage_error)?;
+
+        channel_tree.flush().map_err(to_storage_error)?;
         Ok(())
     }
 
@@ -435,6 +437,8 @@ impl Storage for SledStorageProvider {
         self.sub_channel_tree()?
             .insert(subchannel.channel_id, serialized)
             .map_err(to_storage_error)?;
+
+        self.sub_channel_tree()?.flush().map_err(to_storage_error)?;
         Ok(())
     }
 


### PR DESCRIPTION
Otherwise we can run into invalid-state errors when the node is restarted.