### PR TITLE
Clear certain unprocessed messages after peer disconnect

### DIFF
--- a/dlc-messages/Cargo.toml
+++ b/dlc-messages/Cargo.toml
@@ -16,6 +16,7 @@ dlc = {version = "0.4.0", path = "../dlc"}
 lightning = {version = "0.0.114"}
 secp256k1-zkp = {version = "0.7.0", features = ["bitcoin_hashes", "rand", "rand-std"]}
 serde = {version = "1.0", features = ["derive"], optional = true}
+log = "0.4.14"
 
 [dev-dependencies]
 bitcoin = {version = "0.29.2"}


### PR DESCRIPTION
The DLC message handler implements the `OnionMessageHandler` and `OnionMessageProvider` to be able to hook onto the `peer_disconnected` event. This allows for clearing certain `rust-dlc` messages precisely when a disconnect happens.

We drop the `SubChannelConfirm` and `SubChannelCloseConfirm` messages to avoid bugs such as the one reported [here](https://github.com/get10101/10101/issues/792).

The rest of the implementations of `OnionMessageHandler` and `OnionMessageProvider` is copied from the `IgnoringMessageHandler`.