### PR TITLE
Log deser errors when getting all channels/contracts

### DIFF
--- a/dlc-sled-storage-provider/Cargo.toml
+++ b/dlc-sled-storage-provider/Cargo.toml
@@ -15,6 +15,7 @@ wallet = ["bitcoin", "secp256k1-zkp", "simple-wallet"]
 bitcoin = {version = "0.29", optional = true}
 dlc-manager = {path = "../dlc-manager"}
 lightning = {version = "0.0.114"}
+log = "0.4.14"
 secp256k1-zkp = {version = "0.7", optional = true}
 simple-wallet = {path = "../simple-wallet", optional = true}
 sled = "0.34"

--- a/dlc-sled-storage-provider/src/lib.rs
+++ b/dlc-sled-storage-provider/src/lib.rs
@@ -257,11 +257,18 @@ impl Storage for SledStorageProvider {
     }
 
     fn get_contracts(&self) -> Result<Vec<Contract>, Error> {
-        self.contract_tree()?
+        Ok(self
+            .contract_tree()?
             .iter()
             .values()
-            .map(|x| deserialize_contract(&x.unwrap()))
-            .collect::<Result<Vec<Contract>, Error>>()
+            .filter_map(|x| match deserialize_contract(&x.unwrap()) {
+                Ok(contract) => Some(contract),
+                Err(e) => {
+                    log::error!("Failed to deserialize contract: {e}");
+                    None
+                }
+            })
+            .collect::<Vec<Contract>>())
     }
 
     fn create_contract(&self, contract: &OfferedContract) -> Result<(), Error> {
@@ -458,11 +465,18 @@ impl Storage for SledStorageProvider {
     }
 
     fn get_sub_channels(&self) -> Result<Vec<SubChannel>, Error> {
-        self.sub_channel_tree()?
+        Ok(self
+            .sub_channel_tree()?
             .iter()
             .values()
-            .map(|x| deserialize_sub_channel(&x.unwrap()))
-            .collect::<Result<Vec<SubChannel>, Error>>()
+            .filter_map(|x| match deserialize_sub_channel(&x.unwrap()) {
+                Ok(sub_channel) => Some(sub_channel),
+                Err(e) => {
+                    log::error!("Failed to deserialize subchannel: {e}");
+                    None
+                }
+            })
+            .collect::<Vec<SubChannel>>())
     }
 
     fn get_offered_sub_channels(&self) -> Result<Vec<SubChannel>, Error> {


### PR DESCRIPTION
Before this patch we were immediately failing the entire call to `get_contracts` or `get_sub_channels` in the event of encountering a single deserialisation failure. This can be problematic if we introduce breaking changes and consumers keep around incompatible data.

---

We absolutely don't need to merge this if you think it's too much, @Tibo-lg. In practice, this is a mandatory patch for us at 10101. It's kind of nice to be able to be resilient against these things and it's probably okay since `dlc-sled-storage-provider` is kind of a utility crate.