### PR TITLE
Handle new `Revoke` message in `CustomMessageHandler` impl

### DIFF
--- a/dlc-messages/src/message_handler.rs
+++ b/dlc-messages/src/message_handler.rs
@@ -202,6 +202,7 @@ fn read_dlc_message<R: ::std::io::Read>(
             (SUB_CHANNEL_ACCEPT, Accept),
             (SUB_CHANNEL_CONFIRM, Confirm),
             (SUB_CHANNEL_FINALIZE, Finalize),
+            (SUB_CHANNEL_REVOKE, Revoke),
             (SUB_CHANNEL_CLOSE_OFFER, CloseOffer),
             (SUB_CHANNEL_CLOSE_ACCEPT, CloseAccept),
             (SUB_CHANNEL_CLOSE_CONFIRM, CloseConfirm),


### PR DESCRIPTION
I was surprised to see that this wasn't caught by the tests 😮 We only discovered this when upgrading the `rust-dlc` dependency for the 10101 repo.