### PR TITLE
fix: Add missing renew revoke dlc message

### DIFF
--- a/dlc-messages/src/message_handler.rs
+++ b/dlc-messages/src/message_handler.rs
@@ -193,6 +193,7 @@ fn read_dlc_message<R: ::std::io::Read>(
             (RENEW_CHANNEL_ACCEPT_TYPE, RenewAccept),
             (RENEW_CHANNEL_CONFIRM_TYPE, RenewConfirm),
             (RENEW_CHANNEL_FINALIZE_TYPE, RenewFinalize),
+            (RENEW_CHANNEL_REVOKE_TYPE, RenewRevoke),
             (COLLABORATIVE_CLOSE_OFFER_TYPE, CollaborativeCloseOffer)
         ),
         (


### PR DESCRIPTION
Adds the missing `RenewRevoke` dlc message and fixes

```
lightning::ln::peer_handler[app]: Received unknown even message of type 43026, disconnecting peer!  
```

related to https://github.com/p2pderivatives/rust-dlc/issues/132