### PR TITLE
Add `has_pending_messages_to_process` API to `MessageHandler`

### DIFF
--- a/dlc-messages/src/message_handler.rs
+++ b/dlc-messages/src/message_handler.rs
@@ -88,6 +88,11 @@ impl MessageHandler {
         }
     }
 
+    /// Returns whether there are any new received messages to process.
+    pub fn has_pending_messages_to_process(&self) -> bool {
+        !self.msg_received.lock().unwrap().is_empty()
+    }
+
     /// Returns the messages received by the message handler and empty the
     /// receiving buffer.
     pub fn get_and_clear_received_messages(&self) -> Vec<(PublicKey, Message)> {


### PR DESCRIPTION
To allow consumers to avoid allocating the `Vec` if there are no incoming messages to process.