### PR TITLE
fix: Drop pending Finalize, Accept and CloseAccept messages on disconnected peer

### DIFF
--- a/dlc-messages/src/message_handler.rs
+++ b/dlc-messages/src/message_handler.rs
@@ -117,6 +117,16 @@ impl MessageHandler {
                     );
                     false
                 }
+                Message::SubChannel(SubChannelMessage::Finalize(message))
+                if node_id == disconnected_node_id =>
+                    {
+                        log::warn!(
+                        "Dropping SubChannelFinalize message for channel {:?} \
+                         after peer {node_id} disconnected",
+                        message.channel_id
+                    );
+                        false
+                    }
                 Message::SubChannel(SubChannelMessage::CloseConfirm(message))
                     if node_id == disconnected_node_id =>
                 {
@@ -127,6 +137,16 @@ impl MessageHandler {
                     );
                     false
                 }
+                Message::SubChannel(SubChannelMessage::CloseFinalize(message))
+                if node_id == disconnected_node_id =>
+                    {
+                        log::warn!(
+                        "Dropping SubChannelCloseFinalize message for channel {:?} \
+                         after peer {node_id} disconnected",
+                        message.channel_id
+                    );
+                        false
+                    }
                 // Keep any other message
                 _ => true,
             }

--- a/dlc-messages/src/message_handler.rs
+++ b/dlc-messages/src/message_handler.rs
@@ -137,16 +137,6 @@ impl MessageHandler {
                     );
                     false
                 }
-                Message::SubChannel(SubChannelMessage::CloseFinalize(message))
-                if node_id == disconnected_node_id =>
-                    {
-                        log::warn!(
-                        "Dropping SubChannelCloseFinalize message for channel {:?} \
-                         after peer {node_id} disconnected",
-                        message.channel_id
-                    );
-                        false
-                    }
                 // Keep any other message
                 _ => true,
             }

--- a/dlc-messages/src/message_handler.rs
+++ b/dlc-messages/src/message_handler.rs
@@ -137,6 +137,26 @@ impl MessageHandler {
                     );
                     false
                 }
+                Message::SubChannel(SubChannelMessage::Accept(message))
+                if node_id == disconnected_node_id =>
+                    {
+                        log::warn!(
+                        "Dropping SubChannelAccept message for channel {:?} \
+                         after peer {node_id} disconnected",
+                        message.channel_id
+                    );
+                        false
+                    }
+                Message::SubChannel(SubChannelMessage::CloseAccept(message))
+                if node_id == disconnected_node_id =>
+                    {
+                        log::warn!(
+                        "Dropping SubChannelAccept message for channel {:?} \
+                         after peer {node_id} disconnected",
+                        message.channel_id
+                    );
+                        false
+                    }
                 // Keep any other message
                 _ => true,
             }


### PR DESCRIPTION
I propose to drop the following messages after the counterparty disconnects.

- `Finalize`: After a reconnect before processing the finalize message, both parties will roll back to the `Offered` state. If the party is now trying to process the pending `Finalize` message an `InvalidState` error is reported. This is actually not critical and does not solve any bug, but rather cleans up the logs from a potentially misleading error message.
-  `Accept` & `CloseAccept`: If a reconnect happens in between receiving and processing the `Accept` or `CloseAccept` message, the signatures "break" on the accept message created in the context of the prior established channel, resulting into https://github.com/get10101/10101/issues/1141. This will even break the state in a way that subsequent `Accept` or `CloseAccept` message created in the context on the newly established channel will be successfully processed but fail subsequently on processing the `Finalize` or `FinalizeClose` message resulting into https://github.com/get10101/10101/issues/1074

I am uncertain if this is the right fix, or if the `Invalid state: Misuse error: Invalid commitment signed: Close : Invalid commitment tx signature from peer` shouldn't even happen in the first place. However, this fix resolves our issue as it prevents the scenario from happening.
