### PR TITLE
Fix build with rust-bitcoin-coin-selection

### DIFF
--- a/bitcoin-rpc-provider/Cargo.toml
+++ b/bitcoin-rpc-provider/Cargo.toml
@@ -11,5 +11,5 @@ bitcoincore-rpc-json = {version = "0.16.0"}
 dlc-manager = {path = "../dlc-manager"}
 lightning = {version = "0.0.116"}
 log = "0.4.14"
-rust-bitcoin-coin-selection = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection", features = ["rand"]}
+rust-bitcoin-coin-selection = { version = "0.1.0", git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection", rev = "405451929568422f7df809e35d6ad8f36fccce90", features = ["rand"] }
 simple-wallet = {path = "../simple-wallet"}

--- a/electrs-blockchain-provider/Cargo.toml
+++ b/electrs-blockchain-provider/Cargo.toml
@@ -12,7 +12,7 @@ dlc-manager = {path = "../dlc-manager"}
 lightning = {version = "0.0.116"}
 lightning-block-sync = {version = "0.0.116"}
 reqwest = {version = "0.11", features = ["blocking", "json"]}
-rust-bitcoin-coin-selection = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection", features = ["rand"]}
+rust-bitcoin-coin-selection = { version = "0.1.0", git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection", rev = "405451929568422f7df809e35d6ad8f36fccce90", features = ["rand"] }
 serde = {version = "*", features = ["derive"]}
 simple-wallet = {path = "../simple-wallet"}
 tokio = "1"

--- a/p2pd-oracle-client/src/lib.rs
+++ b/p2pd-oracle-client/src/lib.rs
@@ -133,7 +133,7 @@ fn parse_event_id(event_id: &str) -> Result<(String, DateTime<Utc>), DlcManagerE
     let naive_date_time = NaiveDateTime::from_timestamp_opt(timestamp, 0).ok_or_else(|| {
         DlcManagerError::InvalidParameters(format!("Invalid timestamp {} in event id", timestamp))
     })?;
-    let date_time = DateTime::from_utc(naive_date_time, Utc);
+    let date_time = DateTime::from_naive_utc_and_offset(naive_date_time, Utc);
     Ok((asset_id.to_string(), date_time))
 }
 

--- a/simple-wallet/Cargo.toml
+++ b/simple-wallet/Cargo.toml
@@ -10,7 +10,7 @@ bitcoin = "0.29"
 dlc = {path = "../dlc"}
 dlc-manager = {path = "../dlc-manager"}
 lightning = {version = "0.0.116"}
-rust-bitcoin-coin-selection = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection", features = ["rand"]}
+rust-bitcoin-coin-selection = { version = "0.1.0", git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection", rev = "405451929568422f7df809e35d6ad8f36fccce90", features = ["rand"] }
 secp256k1-zkp = {version = "0.7.0"}
 
 [dev-dependencies]


### PR DESCRIPTION
The latest version of `rust-bitcoin-coin-selection` seems to have broke the build. This pins it to the commit before it broke. May be better to just remove the git repo instead.

Also needed to fix a deprecated function