### PR TITLE
Make Writeable trait public for oracle message

### DIFF
--- a/dlc-messages/src/oracle_msgs.rs
+++ b/dlc-messages/src/oracle_msgs.rs
@@ -7,7 +7,8 @@ use crate::ser_impls::{
 use dlc::{Error, OracleInfo as DlcOracleInfo};
 use lightning::ln::msgs::DecodeError;
 use lightning::ln::wire::Type;
-use lightning::util::ser::{Readable, Writeable, Writer};
+use lightning::util::ser::{Readable, Writer};
+pub use lightning::util::ser::Writeable;
 use secp256k1_zkp::Verification;
 use secp256k1_zkp::{schnorr::Signature, Message, Secp256k1, XOnlyPublicKey};
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Hi !

An oracle needs to sign the TLV encoding of the `OracleEvent` part of his announcement.

Because `Writeable` is declared as private, it seems to me impossible to access the `.encode()` or `write()` functions of an `OracleEvent` which is necessary to get the payload that will be signed with oracle's key to authenticate the announcement.

Maybe I am wrong and there is a simple way to use `.encode()` in an external crate, if not this means it is currently not possible to implement an oracle using `rust-dlc`.

This PR fixes it by declaring the use of the `Writeable` trait public.