### PR TITLE
Do not panic on attempting to force-close a subchannel

### DIFF
--- a/dlc-manager/src/manager.rs
+++ b/dlc-manager/src/manager.rs
@@ -129,7 +129,10 @@ macro_rules! check_for_timed_out_channels {
                 let is_timed_out = timeout < $manager.time.unix_time_now();
                 if is_timed_out {
                     let sub_channel = if channel.is_sub_channel() {
-                        unimplemented!();
+                        error!("Force-closing subchannels is not supported; skipping closure.");
+                        continue;
+
+                        // TODO: Implement subchannel force closing
                         // let s = get_sub_channel_in_state!(
                         //     $manager,
                         //     channel.channel_id,


### PR DESCRIPTION
We have run into this in our public regtest setup, it seems logging an error instead of panicking is safest, as at least it won't bring down the whole app (and it will instead spam the logs).

this is just a quickfix and will not solve the underlying issue.

@Tibo-lg there's come code commented out there - I assume you had some reasons to not try to keep it as is - therefore before jumping into trying to fix this issue properly, I'd like to hear your opinion if you had something in mind :)