### PR TITLE
Use commit tx number to reject stale messages.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "78cbe211" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "78cbe211" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "78cbe211" }
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "b13daab9" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "b13daab9" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "b13daab9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6fd61144" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6fd61144" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6fd61144" }
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "78cbe211" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "78cbe211" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "78cbe211" }

--- a/dlc-manager/src/subchannel/mod.rs
+++ b/dlc-manager/src/subchannel/mod.rs
@@ -408,6 +408,7 @@ where
         &self,
         channel_id: &ChannelId,
         counter_party_node_id: &PublicKey,
+        commit_tx_number: Option<u64>,
         cb: F,
     ) -> Result<T, APIError>
     where
@@ -430,7 +431,7 @@ where
         funding_outpoint: &OutPoint,
         channel_value_satoshis: u64,
         value_to_self_msat: u64,
-    ) -> Result<CommitmentSigned, APIError>;
+    ) -> Result<(CommitmentSigned, u64), APIError>;
     /// Provides commitment transaction and HTLCs signatures and returns a [`RevokeAndACK`]
     /// message.
     fn on_commitment_signed_get_raa(
@@ -512,7 +513,7 @@ where
         funding_outpoint: &OutPoint,
         channel_value_satoshis: u64,
         value_to_self_msat: u64,
-    ) -> Result<CommitmentSigned, APIError> {
+    ) -> Result<(CommitmentSigned, u64), APIError> {
         self.get_updated_funding_outpoint_commitment_signed(
             channel_lock,
             &lightning::chain::transaction::OutPoint {
@@ -569,6 +570,7 @@ where
         &self,
         channel_id: &ChannelId,
         counter_party_node_id: &PublicKey,
+        commit_tx_number: Option<u64>,
         cb: C,
     ) -> Result<RV, APIError>
     where
@@ -576,7 +578,7 @@ where
             &mut ChannelLock<<<K as Deref>::Target as SignerProvider>::Signer>,
         ) -> Result<RV, APIError>,
     {
-        self.with_useable_channel_lock(channel_id, counter_party_node_id, cb)
+        self.with_useable_channel_lock(channel_id, counter_party_node_id, commit_tx_number, cb)
     }
 
     fn with_channel_lock_no_check<C, RV>(

--- a/dlc-messages/src/message_handler.rs
+++ b/dlc-messages/src/message_handler.rs
@@ -48,37 +48,6 @@ impl lightning::events::OnionMessageProvider for MessageHandler {
     }
 }
 
-impl lightning::ln::msgs::OnionMessageHandler for MessageHandler {
-    fn handle_onion_message(
-        &self,
-        _their_node_id: &PublicKey,
-        _msg: &lightning::ln::msgs::OnionMessage,
-    ) {
-    }
-    fn peer_connected(
-        &self,
-        _their_node_id: &PublicKey,
-        _init: &lightning::ln::msgs::Init,
-        _inbound: bool,
-    ) -> Result<(), ()> {
-        Ok(())
-    }
-
-    fn peer_disconnected(&self, their_node_id: &PublicKey) {
-        self.clear_pending_messages_sent_by_node(their_node_id);
-    }
-
-    fn provided_node_features(&self) -> lightning::ln::features::NodeFeatures {
-        lightning::ln::features::NodeFeatures::empty()
-    }
-    fn provided_init_features(
-        &self,
-        _their_node_id: &PublicKey,
-    ) -> lightning::ln::features::InitFeatures {
-        lightning::ln::features::InitFeatures::empty()
-    }
-}
-
 impl MessageHandler {
     /// Creates a new instance of a [`MessageHandler`]
     pub fn new() -> Self {
@@ -100,38 +69,6 @@ impl MessageHandler {
         let mut ret = Vec::new();
         std::mem::swap(&mut *self.msg_received.lock().unwrap(), &mut ret);
         ret
-    }
-
-    /// Drops certain pending messages sent by the remote node.
-    pub fn clear_pending_messages_sent_by_node(&self, disconnected_node_id: &PublicKey) {
-        let messages = &mut *self.msg_received.lock().unwrap();
-
-        messages.retain(|(node_id, message)| {
-            match message {
-                Message::SubChannel(SubChannelMessage::Confirm(message))
-                    if node_id == disconnected_node_id =>
-                {
-                    log::warn!(
-                        "Dropping SubChannelConfirm message for channel {:?} \
-                         after peer {node_id} disconnected",
-                        message.channel_id
-                    );
-                    false
-                }
-                Message::SubChannel(SubChannelMessage::CloseConfirm(message))
-                    if node_id == disconnected_node_id =>
-                {
-                    log::warn!(
-                        "Dropping SubChannelCloseConfirm message for channel {:?} \
-                         after peer {node_id} disconnected",
-                        message.channel_id
-                    );
-                    false
-                }
-                // Keep any other message
-                _ => true,
-            }
-        });
     }
 
     /// Send a message to the peer with given node id. Not that the message is not

--- a/dlc-messages/src/sub_channel.rs
+++ b/dlc-messages/src/sub_channel.rs
@@ -102,6 +102,8 @@ pub struct SubChannelAccept {
     pub own_basepoint: PublicKey,
     /// The signature for the new commit transaction of the Lightning channel.
     pub commit_signature: Signature,
+    /// The commit transaction number for which the above signature is intended.
+    pub commit_tx_number: u64,
     /// The htlc signatures for the new commit transaction of the Lightning channel.
     pub htlc_signatures: Vec<Signature>,
     /// The first point used to derive public private key pairs used for the split transaction.
@@ -139,6 +141,7 @@ impl_dlc_writeable!(
     (publish_basepoint, writeable),
     (own_basepoint, writeable),
     (commit_signature, writeable),
+    (commit_tx_number, writeable),
     (htlc_signatures, writeable),
     (first_per_split_point, writeable),
     (channel_revocation_basepoint, writeable),
@@ -168,6 +171,8 @@ pub struct SubChannelConfirm {
     pub split_adaptor_signature: EcdsaAdaptorSignature,
     /// The signature for the new commitment transaction.
     pub commit_signature: Signature,
+    /// The commit transaction number for which the above signature is intended.
+    pub commit_tx_number: u64,
     /// The htlc signatures for the new commitment transaction.
     pub htlc_signatures: Vec<Signature>,
     /// The adaptor signatures for the DLC channel CETs.
@@ -185,6 +190,7 @@ impl_dlc_writeable!(SubChannelConfirm, {
     (channel_id, writeable),
     (split_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}),
     (commit_signature, writeable),
+    (commit_tx_number, writeable),
     (htlc_signatures, writeable),
     (cet_adaptor_signatures, writeable),
     (buffer_adaptor_signature, {cb_writeable, write_ecdsa_adaptor_signature, read_ecdsa_adaptor_signature}),
@@ -274,6 +280,8 @@ pub struct SubChannelCloseAccept {
     /// The signature for the new commitment transaction The signature for the new commitment
     /// transaction.
     pub commit_signature: Signature,
+    /// The commit transaction number for which the above signature is intended.
+    pub commit_tx_number: u64,
     /// The htlc signatures for the new commitment transactions.
     pub htlc_signatures: Vec<Signature>,
 }
@@ -281,6 +289,7 @@ pub struct SubChannelCloseAccept {
 impl_dlc_writeable!(SubChannelCloseAccept, {
     (channel_id, writeable),
     (commit_signature, writeable),
+    (commit_tx_number, writeable),
     (htlc_signatures, writeable)
 });
 
@@ -298,6 +307,8 @@ pub struct SubChannelCloseConfirm {
     /// The signature for the new commitment transaction The signature for the new commitment
     /// transaction.
     pub commit_signature: Signature,
+    /// The commit transaction number for which the above signature is intended.
+    pub commit_tx_number: u64,
     /// The htlc signatures for the new commitment transactions.
     pub htlc_signatures: Vec<Signature>,
     /// The pre-image of the split transaction revocation point.
@@ -311,6 +322,7 @@ pub struct SubChannelCloseConfirm {
 impl_dlc_writeable!(SubChannelCloseConfirm, {
     (channel_id, writeable),
     (commit_signature, writeable),
+    (commit_tx_number, writeable),
     (htlc_signatures, writeable),
     (split_revocation_secret, writeable),
     (commit_revocation_secret, writeable),


### PR DESCRIPTION
This PR aims to fix the issue where stale messages are receive and mess up the internal state of the LDK node. It does so by embedding the commitment transaction number together with commitment signatures, and checking that we are given the expected one within the `with_useable_channel_lock` method.

I reverted previous changes to the message handler dropping messages on disconnect as I believe they are not necessary anymore with this change.

I can't promise that all concurrency issues will be resolved by this patch, but it should at least be more robust than it currently is.

(Leaving as draft for now as it builds on top of #141 which is not merged yet).