### PR TITLE
feat: Add optional fee to be paid to the offering party

### DIFF
--- a/dlc-manager/benches/benchmarks.rs
+++ b/dlc-manager/benches/benchmarks.rs
@@ -112,7 +112,7 @@ fn create_contract_descriptor() -> ContractDescriptor {
                 ])
                 .unwrap(),
             ),
-        ])
+        ], None)
         .unwrap(),
         rounding_intervals: RoundingIntervals {
             intervals: vec![RoundingInterval {

--- a/dlc-manager/src/contract/ser.rs
+++ b/dlc-manager/src/contract/ser.rs
@@ -63,7 +63,7 @@ impl_dlc_writeable_enum!(
     (1, HyperbolaPayoutCurvePiece);;;
 );
 impl_dlc_writeable!(RoundingInterval, { (begin_interval, writeable), (rounding_mod, writeable) });
-impl_dlc_writeable!(PayoutFunction, { (payout_function_pieces, vec) });
+impl_dlc_writeable!(PayoutFunction, { (payout_function_pieces, vec), (fee, option) });
 impl_dlc_writeable!(NumericalDescriptor, { (payout_function, writeable), (rounding_intervals, writeable), (difference_params, option), (oracle_numeric_infos, {cb_writeable, oracle_params::write, oracle_params::read}) });
 impl_dlc_writeable!(PolynomialPayoutCurvePiece, { (payout_points, vec) });
 impl_dlc_writeable!(RoundingIntervals, { (intervals, vec) });

--- a/dlc-manager/src/conversion_utils.rs
+++ b/dlc-manager/src/conversion_utils.rs
@@ -319,6 +319,7 @@ impl From<&ContractDescriptor> for SerContractDescriptor {
 impl From<&PayoutFunction> for SerPayoutFunction {
     fn from(payout_function: &PayoutFunction) -> SerPayoutFunction {
         SerPayoutFunction {
+            fee: payout_function.fee,
             payout_function_pieces: payout_function
                 .payout_function_pieces
                 .iter()
@@ -367,6 +368,7 @@ impl From<&PayoutFunction> for SerPayoutFunction {
 impl From<&SerPayoutFunction> for PayoutFunction {
     fn from(payout_function: &SerPayoutFunction) -> PayoutFunction {
         PayoutFunction {
+            fee: payout_function.fee,
             payout_function_pieces: payout_function
                 .payout_function_pieces
                 .iter()
@@ -552,6 +554,7 @@ mod tests {
     #[test]
     fn payout_function_round_trip() {
         let payout_function = PayoutFunction {
+            fee: None,
             payout_function_pieces: vec![
                 PayoutFunctionPiece::PolynomialPayoutCurvePiece(PolynomialPayoutCurvePiece {
                     payout_points: vec![

--- a/dlc-manager/tests/test_utils.rs
+++ b/dlc-manager/tests/test_utils.rs
@@ -477,7 +477,7 @@ pub fn get_numerical_contract_descriptor(
     difference_params: Option<DifferenceParams>,
 ) -> ContractDescriptor {
     ContractDescriptor::Numerical(NumericalDescriptor {
-        payout_function: PayoutFunction::new(function_pieces).unwrap(),
+        payout_function: PayoutFunction::new(function_pieces, None).unwrap(),
         rounding_intervals: RoundingIntervals {
             intervals: vec![RoundingInterval {
                 begin_interval: 0,

--- a/dlc-messages/src/contract_msgs.rs
+++ b/dlc-messages/src/contract_msgs.rs
@@ -178,9 +178,11 @@ pub struct PayoutFunction {
     pub payout_function_pieces: Vec<PayoutFunctionPiece>,
     /// The right most point of the function.
     pub last_endpoint: PayoutPoint,
+    /// An optional fee deducted by the offering party in the payouts.
+    pub fee: Option<u64>,
 }
 
-impl_dlc_writeable!(PayoutFunction, {(payout_function_pieces, vec), (last_endpoint, writeable)});
+impl_dlc_writeable!(PayoutFunction, {(payout_function_pieces, vec), (last_endpoint, writeable), (fee, option) });
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(


### PR DESCRIPTION
Adds an optional fee to be added to the payout function. This fee will be deducted from the accepting party payouts. This allows the offering party to charge for a fee his offering.

In 10101 we used to charge fees by automatically paying an invoice issued by the coordinator, which is not optimal as 

1. It is a trusted setup, where the coordinator trusts that the counter party pays the invoice.
2. It is pretty failure prune to immediately pay an invoice after updating the subchannel. We used to add a 5 seconds sleep to ensure everything is updated.

This change will allow us to charge fees (unilaterally) in an un-trusted way.