### PR TITLE
Update rust-lightning dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "b13daab9" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "b13daab9" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "b13daab9" }
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a57281b" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a57281b" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a57281b" }


### PR DESCRIPTION
The backwards-compatibility problem is associated with the recent upgrade to `rust-lightning:0.0.116`.