### PR TITLE
Update to tip of `p2pderivatives/rust-lightning#split-channel-experiment-116`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "b13daab9" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "b13daab9" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "b13daab9" }
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "9a9cecda" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "9a9cecda" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "9a9cecda" }


### PR DESCRIPTION
Nothing new other than updating to the tip of `p2pderivatives/rust-lightning#split-channel-experiment-116`, instead
of depending on a merged PR branch.