### PR TITLE
Load ChainMonitor in (DLC) Manager constructor if possible

### DIFF
--- a/dlc-manager/src/manager.rs
+++ b/dlc-manager/src/manager.rs
@@ -174,6 +174,10 @@ where
         time: T,
         fee_estimator: F,
     ) -> Result<Self, Error> {
+        let chain_monitor = store
+            .get_chain_monitor()?
+            .unwrap_or(ChainMonitor::new(blockchain.get_blockchain_height()?));
+
         Ok(Manager {
             secp: secp256k1_zkp::Secp256k1::new(),
             wallet,
@@ -181,7 +185,7 @@ where
             oracles,
             time,
             fee_estimator,
-            chain_monitor: Mutex::new(ChainMonitor::new(blockchain.get_blockchain_height()?)),
+            chain_monitor: Mutex::new(chain_monitor),
             blockchain,
         })
     }


### PR DESCRIPTION
Otherwise we forget about all the registered transactions on restart, which can lead to loss of funds.