### PR TITLE
Change Signer::sign_tx_input to Signer::sign_psbt_input

### DIFF
--- a/dlc-manager/src/channel_updater.rs
+++ b/dlc-manager/src/channel_updater.rs
@@ -435,7 +435,7 @@ pub fn verify_signed_channel<S: Deref>(
     accepted_contract: &AcceptedContract,
     sign_channel: &SignChannel,
     signer: &S,
-) -> Result<(SignedChannel, SignedContract), Error>
+) -> Result<(SignedChannel, SignedContract, Transaction), Error>
 where
     S::Target: Signer,
 {
@@ -458,7 +458,7 @@ where
 
     let cet_adaptor_signatures: Vec<_> = (&sign_channel.cet_adaptor_signatures).into();
 
-    let (signed_contract, fund_tx) = verify_signed_contract_internal(
+    let (signed_contract, signed_fund_tx) = verify_signed_contract_internal(
         secp,
         accepted_contract,
         &sign_channel.refund_signature,
@@ -493,7 +493,11 @@ where
             is_offer: false,
         },
         update_idx: INITIAL_UPDATE_NUMBER,
-        fund_tx,
+        fund_tx: signed_contract
+            .accepted_contract
+            .dlc_transactions
+            .fund
+            .clone(),
         fund_script_pubkey: accepted_contract
             .dlc_transactions
             .funding_script_pubkey
@@ -507,7 +511,7 @@ where
             .fee_rate_per_vb,
     };
 
-    Ok((signed_channel, signed_contract))
+    Ok((signed_channel, signed_contract, signed_fund_tx))
 }
 
 /// Creates a [`SettleOffer`] message from the given [`SignedChannel`] and parameters,

--- a/dlc-manager/src/lib.rs
+++ b/dlc-manager/src/lib.rs
@@ -36,6 +36,7 @@ pub mod manager;
 pub mod payout_curve;
 mod utils;
 
+use bitcoin::psbt::PartiallySignedTransaction;
 use bitcoin::{Address, Block, OutPoint, Script, Transaction, TxOut, Txid};
 use chain_monitor::ChainMonitor;
 use channel::offered_channel::OfferedChannel;
@@ -78,12 +79,10 @@ impl Time for SystemTimeProvider {
 /// Provides signing related functionalities.
 pub trait Signer {
     /// Signs a transaction input
-    fn sign_tx_input(
+    fn sign_psbt_input(
         &self,
-        tx: &mut Transaction,
+        psbt: &mut PartiallySignedTransaction,
         input_index: usize,
-        tx_out: &TxOut,
-        redeem_script: Option<Script>,
     ) -> Result<(), Error>;
     /// Get the secret key associated with the provided public key.
     fn get_secret_key_for_pubkey(&self, pubkey: &PublicKey) -> Result<SecretKey, Error>;

--- a/dlc-manager/src/manager.rs
+++ b/dlc-manager/src/manager.rs
@@ -1390,7 +1390,7 @@ where
             Some(*peer_id)
         )?;
 
-        let (signed_channel, signed_contract) = {
+        let (signed_channel, signed_contract, signed_fund_tx) = {
             let res = verify_signed_channel(
                 &self.secp,
                 &accepted_channel,
@@ -1430,7 +1430,7 @@ where
             unreachable!();
         }
 
-        self.blockchain.send_transaction(&signed_channel.fund_tx)?;
+        self.blockchain.send_transaction(&signed_fund_tx)?;
 
         self.store.upsert_channel(
             Channel::Signed(signed_channel),

--- a/mocks/src/mock_wallet.rs
+++ b/mocks/src/mock_wallet.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use bitcoin::psbt::PartiallySignedTransaction;
 use bitcoin::{Address, PackedLockTime, Script, Transaction, TxOut};
 use dlc_manager::{error::Error, Blockchain, Signer, Utxo, Wallet};
 use secp256k1_zkp::{rand::seq::SliceRandom, SecretKey};
@@ -45,13 +46,11 @@ impl MockWallet {
 }
 
 impl Signer for MockWallet {
-    fn sign_tx_input(
+    fn sign_psbt_input(
         &self,
-        _tx: &mut bitcoin::Transaction,
-        _input_index: usize,
-        _tx_out: &bitcoin::TxOut,
-        _redeem_script: Option<bitcoin::Script>,
-    ) -> Result<(), dlc_manager::error::Error> {
+        _psbt: &mut PartiallySignedTransaction,
+        _idx: usize,
+    ) -> Result<(), Error> {
         Ok(())
     }
 


### PR DESCRIPTION
With the previous API, signing taproot inputs comes with a lot of problems. Taproot signatures commit to the previous txo of all the inputs so to be able to construct a signature, you need to have all of them available. The previous API would require the user to look up the outputs themself which does not really work for mobile clients and it is a bad practice. This changes it to a PSBT so we can give all the necessary info to the user directly.