### PR TITLE
Re-export secp256k1_zkp

### DIFF
--- a/dlc-messages/src/message_handler.rs
+++ b/dlc-messages/src/message_handler.rs
@@ -94,7 +94,8 @@ macro_rules! handle_read_dlc_messages {
     }};
 }
 
-fn read_dlc_message<R: ::lightning::io::Read>(
+/// Parses a DLC message from a buffer.
+pub fn read_dlc_message<R: ::lightning::io::Read>(
     msg_type: u16,
     mut buffer: &mut R,
 ) -> Result<Option<WireMessage>, DecodeError> {

--- a/dlc/Cargo.toml
+++ b/dlc/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 # for benchmarks
 unstable = []
 default = ["std"]
-std = ["bitcoin/std", "miniscript/std"]
+std = ["bitcoin/std", "miniscript/std", "secp256k1-zkp/rand-std"]
 no-std = ["dep:hashbrown", "miniscript/no-std", "bitcoin/no-std"]
 use-serde = ["serde", "secp256k1-zkp/use-serde"]
 

--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -16,7 +16,7 @@ extern crate bitcoin;
 extern crate core;
 extern crate miniscript;
 extern crate secp256k1_sys;
-extern crate secp256k1_zkp;
+pub extern crate secp256k1_zkp;
 #[cfg(feature = "serde")]
 extern crate serde;
 


### PR DESCRIPTION
Re-exports `secp256k1_zkp` since a lof of the types are leaked in the API and just makes it easier to get from rust-dlc instead of having to import the library yourself. Needed to enable the rand-std flag for external use too.

Also makes `read_dlc_message` public so you can manually parse dlc messages externally.