### PR TITLE
Remove reliance on predefined Oracles

### DIFF
--- a/dlc-manager/src/manager.rs
+++ b/dlc-manager/src/manager.rs
@@ -271,19 +271,33 @@ where
 
     /// Function called to create a new DLC. The offered contract will be stored
     /// and an OfferDlc message returned.
+    ///
+    /// This function will fetch the oracle announcements from the oracle.
     pub fn send_offer(
         &mut self,
         contract_input: &ContractInput,
         counter_party: PublicKey,
     ) -> Result<OfferDlc, Error> {
-        contract_input.validate()?;
-
         let oracle_announcements = contract_input
             .contract_infos
             .iter()
             .map(|x| self.get_oracle_announcements(&x.oracles))
             .collect::<Result<Vec<_>, Error>>()?;
 
+        self.send_offer_with_announcements(contract_input, counter_party, oracle_announcements)
+    }
+
+    /// Function called to create a new DLC. The offered contract will be stored
+    /// and an OfferDlc message returned.
+    ///
+    /// This function allows to pass the oracle announcements directly instead of
+    /// fetching them from the oracle.
+    pub fn send_offer_with_announcements(
+        &mut self,
+        contract_input: &ContractInput,
+        counter_party: PublicKey,
+        oracle_announcements: Vec<Vec<OracleAnnouncement>>,
+    ) -> Result<OfferDlc, Error> {
         let (offered_contract, offer_msg) = crate::contract_updater::offer_contract(
             &self.secp,
             contract_input,

--- a/dlc-messages/src/oracle_msgs.rs
+++ b/dlc-messages/src/oracle_msgs.rs
@@ -314,6 +314,17 @@ pub struct OracleAttestation {
     pub outcomes: Vec<String>,
 }
 
+impl OracleAttestation {
+    /// Returns the nonces used by the oracle to sign the event outcome.
+    /// This is used for finding the matching oracle announcement.
+    pub fn nonces(&self) -> Vec<XOnlyPublicKey> {
+        self.signatures
+            .iter()
+            .map(|s| XOnlyPublicKey::from_slice(&s[0..32]).expect("valid signature"))
+            .collect()
+    }
+}
+
 impl Type for OracleAttestation {
     fn type_id(&self) -> u16 {
         ATTESTATION_TYPE

--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -144,6 +144,14 @@ impl DlcTransactions {
             .unwrap()
             .0
     }
+
+    /// Get the outpoint for the fund output in the fund transaction
+    pub fn get_fund_outpoint(&self) -> OutPoint {
+        OutPoint {
+            txid: self.fund.txid(),
+            vout: self.get_fund_output_index() as u32,
+        }
+    }
 }
 
 /// Contains info about a utxo used for funding a DLC contract


### PR DESCRIPTION
Closes #174 

Going to work on adding tests but I think this is all that is needed to get around the requirement of having an `Oracle` defined upfront