### PR TITLE
Fix clippy warnings in tests

### DIFF
--- a/dlc-manager/tests/test_utils.rs
+++ b/dlc-manager/tests/test_utils.rs
@@ -62,6 +62,7 @@ macro_rules! receive_loop {
                             Some(msg) => {
                                 let msg_opt = $rcv_callback(msg);
                                 if let Some(msg) = msg_opt {
+                                    #[allow(clippy::redundant_closure_call)]
                                     $msg_callback(&msg);
                                     (&$send).send(Some(msg)).expect("Error sending");
                                 }

--- a/dlc-sled-storage-provider/src/lib.rs
+++ b/dlc-sled-storage-provider/src/lib.rs
@@ -667,6 +667,7 @@ mod tests {
                 let path = format!("{}{}", "test_files/sleddb/", std::stringify!($name));
                 {
                     let storage = SledStorageProvider::new(&path).expect("Error opening sled DB");
+                    #[allow(clippy::redundant_closure_call)]
                     $body(storage);
                 }
                 std::fs::remove_dir_all(path).unwrap();


### PR DESCRIPTION
I get these clippy warnings when using nightly rust. I don't see a nice way of handling this in the macro without just allowing it, doesn't seem to be a huge deal.

https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_closure