### PR TITLE
Evaluating payout curve fails

### DIFF
--- a/dlc-manager/src/payout_curve.rs
+++ b/dlc-manager/src/payout_curve.rs
@@ -1290,4 +1290,38 @@ mod test {
         assert_eq!(polynomial.evaluate(0), 10.0);
         assert_eq!(polynomial.evaluate(1), 8.0);
     }
+
+    #[test]
+    fn try_to_get_negative() {
+        let total_collateral_doesnt_matter = 1324451 + 1324451;
+
+        let polynomial = PolynomialPayoutCurvePiece {
+            payout_points: vec![
+                PayoutPoint {
+                    event_outcome: 25207,
+                    outcome_payout: 2648902,
+                    extra_precision: 0,
+                },
+                PayoutPoint {
+                    event_outcome: 25227,
+                    outcome_payout: 2647503,
+                    extra_precision: 0,
+                },
+            ],
+        };
+
+
+        // this is where our payout curve fails
+        let outcome = 1048575;
+
+        let doesnt_matter = RoundingIntervals {
+            intervals: vec![RoundingInterval {
+                begin_interval: 0,
+                rounding_mod: 0,
+            }],
+        };
+        let result = polynomial.get_rounded_payout(outcome, &doesnt_matter, total_collateral_doesnt_matter);
+        // TODO: this should not fail I think
+        result.unwrap();
+    }
 }


### PR DESCRIPTION
the file below includes the payout curve we calculated

[computed_payout.csv](https://github.com/p2pderivatives/rust-dlc/files/13494487/computed_payout.csv)


We constructed the curve with 

```
lower_event_outcome;lower_payout;extra_precission;upper_event_outcome;upper_payout;extra_precission
```

```
let lower_range = PolynomialPayoutCurvePiece::new(vec![
            dlc_manager::payout_curve::PayoutPoint {
                event_outcome: lower.event_outcome,
                outcome_payout: lower.lower_payout,
                extra_precision: lower.extra_precission,
            },
            dlc_manager::payout_curve::PayoutPoint {
                event_outcome: upper.event_outcome,
                outcome_payout: upper.upper_payout,
                extra_precision: upper.extra_precission,
            },
        ])?;
        pieces.push(PayoutFunctionPiece::PolynomialPayoutCurvePiece(lower_range));
		let payout_function =
        PayoutFunction::new(pieces).context("could not create payout function")?;
```