### PR TITLE
return counterparty pk when rejecting subchannel offer and handle rejected state

### DIFF
--- a/dlc-manager/src/sub_channel_manager.rs
+++ b/dlc-manager/src/sub_channel_manager.rs
@@ -1480,7 +1480,7 @@ where
     }
 
     /// Reject an offer to establish a sub channel.
-    pub fn reject_sub_channel_offer(&self, channel_id: ChannelId) -> Result<Reject, Error> {
+    pub fn reject_sub_channel_offer(&self, channel_id: ChannelId) -> Result<(PublicKey, Reject), Error> {
         let (mut sub_channel, _) = get_sub_channel_in_state!(
             self.dlc_channel_manager,
             channel_id,
@@ -1494,7 +1494,7 @@ where
             .get_store()
             .upsert_sub_channel(&sub_channel)?;
 
-        Ok(Reject { channel_id })
+        Ok((sub_channel.counter_party, Reject { channel_id }))
     }
 
     /// Reject an offer to collaboratively close a sub channel off chain.

--- a/dlc-manager/src/sub_channel_manager.rs
+++ b/dlc-manager/src/sub_channel_manager.rs
@@ -340,7 +340,7 @@ where
                 .get_sub_channel(channel_details.channel_id)?
             {
                 Some(mut s) => match s.state {
-                    SubChannelState::OffChainClosed => {
+                    SubChannelState::OffChainClosed | SubChannelState::Rejected => {
                         s.is_offer = true;
                         s.update_idx -= 1;
 
@@ -1585,7 +1585,7 @@ where
                 .get_sub_channel(channel_details.channel_id)?
             {
                 Some(mut s) => match s.state {
-                    SubChannelState::OffChainClosed => {
+                    SubChannelState::OffChainClosed | SubChannelState::Rejected => {
                         s.is_offer = false;
                         s.update_idx -= 1;
                         Some(s)

--- a/dlc-manager/tests/ln_dlc_channel_execution_tests.rs
+++ b/dlc-manager/tests/ln_dlc_channel_execution_tests.rs
@@ -2860,7 +2860,7 @@ fn reject_offer(test_params: &LnDlcTestParams) {
         Offered
     );
 
-    let reject = test_params
+    let (_, reject) = test_params
         .bob_node
         .sub_channel_manager
         .reject_sub_channel_offer(test_params.channel_id)

--- a/dlc-manager/tests/ln_dlc_channel_execution_tests.rs
+++ b/dlc-manager/tests/ln_dlc_channel_execution_tests.rs
@@ -951,6 +951,29 @@ fn ln_dlc_rejected_offer() {
     reject_offer(&test_params);
 }
 
+
+#[test]
+#[ignore]
+fn ln_dlc_rejected_offer_then_new_offer_and_accept_offer() {
+    let test_params = test_init();
+    make_ln_payment(&test_params.alice_node, &test_params.bob_node, 900000);
+
+    reject_offer(&test_params);
+
+    open_sub_channel(&test_params);
+
+    assert_sub_channel_state!(
+        test_params.alice_node.sub_channel_manager,
+        &test_params.channel_id,
+        Signed
+    );
+    assert_sub_channel_state!(
+        test_params.bob_node.sub_channel_manager,
+        &test_params.channel_id,
+        Signed
+    );
+}
+
 #[test]
 #[ignore]
 fn ln_dlc_rejected_close() {


### PR DESCRIPTION
Useful because we will need to send the reject message afterwards and for that we need to know to whom.