### PR TITLE
Support taproot signing

### DIFF
--- a/bitcoin-rpc-provider/src/lib.rs
+++ b/bitcoin-rpc-provider/src/lib.rs
@@ -189,9 +189,10 @@ impl Signer for BitcoinCoreProvider {
         &self,
         tx: &mut Transaction,
         input_index: usize,
-        tx_out: &TxOut,
+        tx_outs: &[TxOut],
         redeem_script: Option<Script>,
     ) -> Result<(), ManagerError> {
+        let tx_out = tx_outs.get(input_index).ok_or(Error::InvalidState)?;
         let outpoint = &tx.input[input_index].previous_output;
 
         let input = json::SignRawTransactionInput {

--- a/dlc-manager/src/lib.rs
+++ b/dlc-manager/src/lib.rs
@@ -82,7 +82,7 @@ pub trait Signer {
         &self,
         tx: &mut Transaction,
         input_index: usize,
-        tx_out: &TxOut,
+        prev_outputs: &[TxOut],
         redeem_script: Option<Script>,
     ) -> Result<(), Error>;
     /// Get the secret key associated with the provided public key.

--- a/mocks/src/mock_wallet.rs
+++ b/mocks/src/mock_wallet.rs
@@ -49,7 +49,7 @@ impl Signer for MockWallet {
         &self,
         _tx: &mut bitcoin::Transaction,
         _input_index: usize,
-        _tx_out: &bitcoin::TxOut,
+        _tx_out: &[TxOut],
         _redeem_script: Option<bitcoin::Script>,
     ) -> Result<(), dlc_manager::error::Error> {
         Ok(())


### PR DESCRIPTION
Alternative to #172 

To be honest this doesn't feel any cleaner to me, it cleans up the implementations of the example wallets because they are using special functions meant for this current api but the dlc-manager code still has the same complexity because we have to get all the previous utxos.