### PR TITLE
Add get_new_change_address() to wallet

### DIFF
--- a/bitcoin-rpc-provider/src/lib.rs
+++ b/bitcoin-rpc-provider/src/lib.rs
@@ -227,6 +227,10 @@ impl Wallet for BitcoinCoreProvider {
             .map_err(rpc_err_to_manager_err)
     }
 
+    fn get_new_change_address(&self) -> Result<Address, ManagerError> {
+        self.get_new_address()
+    }
+
     fn get_new_secret_key(&self) -> Result<SecretKey, ManagerError> {
         let sk = SecretKey::new(&mut thread_rng());
         let network = self.get_network()?;

--- a/dlc-manager/src/lib.rs
+++ b/dlc-manager/src/lib.rs
@@ -94,6 +94,8 @@ pub trait Signer {
 pub trait Wallet: Signer {
     /// Returns a new (unused) address.
     fn get_new_address(&self) -> Result<Address, Error>;
+    /// Returns a new (unused) change address.
+    fn get_new_change_address(&self) -> Result<Address, Error>;
     /// Generate a new secret key and store it in the wallet so that it can later
     /// be retrieved.
     fn get_new_secret_key(&self) -> Result<SecretKey, Error>;

--- a/dlc-manager/src/utils.rs
+++ b/dlc-manager/src/utils.rs
@@ -76,7 +76,7 @@ where
     let payout_addr = wallet.get_new_address()?;
     let payout_spk = payout_addr.script_pubkey();
     let payout_serial_id = get_new_serial_id();
-    let change_addr = wallet.get_new_address()?;
+    let change_addr = wallet.get_new_change_address()?;
     let change_spk = change_addr.script_pubkey();
     let change_serial_id = get_new_serial_id();
 

--- a/mocks/src/mock_wallet.rs
+++ b/mocks/src/mock_wallet.rs
@@ -68,6 +68,10 @@ impl Wallet for MockWallet {
         Ok(get_address())
     }
 
+    fn get_new_change_address(&self) -> Result<Address, dlc_manager::error::Error> {
+        Ok(get_address())
+    }
+
     fn get_new_secret_key(&self) -> Result<SecretKey, dlc_manager::error::Error> {
         Ok(get_secret_key())
     }

--- a/simple-wallet/src/lib.rs
+++ b/simple-wallet/src/lib.rs
@@ -219,6 +219,10 @@ where
         Ok(address)
     }
 
+    fn get_new_change_address(&self) -> Result<Address> {
+        self.get_new_address()
+    }
+
     fn get_new_secret_key(&self) -> Result<SecretKey> {
         let seckey = SecretKey::new(&mut thread_rng());
         let pubkey = PublicKey::from_secret_key(&self.secp_ctx, &seckey);


### PR DESCRIPTION
A lot of wallets treat change addresses vs external addresses differently. Being able to specificy what the address is being used for lets the wallet generate the correct kind.