### PR TITLE
fix: Add missing reject message

### DIFF
--- a/dlc-messages/src/message_handler.rs
+++ b/dlc-messages/src/message_handler.rs
@@ -116,7 +116,8 @@ pub fn read_dlc_message<R: ::lightning::io::Read>(
         (RENEW_CHANNEL_ACCEPT_TYPE, RenewAccept),
         (RENEW_CHANNEL_CONFIRM_TYPE, RenewConfirm),
         (RENEW_CHANNEL_FINALIZE_TYPE, RenewFinalize),
-        (COLLABORATIVE_CLOSE_OFFER_TYPE, CollaborativeCloseOffer)
+        (COLLABORATIVE_CLOSE_OFFER_TYPE, CollaborativeCloseOffer),
+        (REJECT, Reject)
     )
 }
 


### PR DESCRIPTION
Adds the missing `Reject` dlc message and fixes

```
lightning::ln::peer_handler[app]: Received unknown even message of type 43024, disconnecting peer!  
```

related to https://github.com/p2pderivatives/rust-dlc/issues/132