### PR TITLE
fix: Set timeout on `RenewOffered` state

### DIFF
--- a/dlc-manager/src/channel_updater.rs
+++ b/dlc-manager/src/channel_updater.rs
@@ -1023,10 +1023,15 @@ where
 /// Update the state of the given [`SignedChannel`] from the given [`RenewOffer`].
 /// Expects the channel to be in one of [`SignedChannelState::Settled`] or
 /// [`SignedChannelState::Established`] state.
-pub fn on_renew_offer(
+pub fn on_renew_offer<T: Deref>(
     signed_channel: &mut SignedChannel,
     renew_offer: &RenewOffer,
-) -> Result<OfferedContract, Error> {
+    peer_timeout: u64,
+    time: &T,
+) -> Result<OfferedContract, Error>
+    where
+        T::Target: Time,
+{
     if let SignedChannelState::Settled { .. } | SignedChannelState::Established { .. } =
         signed_channel.state
     {
@@ -1058,7 +1063,7 @@ pub fn on_renew_offer(
         counter_payout: renew_offer.counter_payout,
         offer_next_per_update_point: renew_offer.next_per_update_point,
         is_offer: false,
-        timeout: 0,
+        timeout: time.unix_time_now() + peer_timeout,
     };
 
     std::mem::swap(&mut signed_channel.state, &mut state);

--- a/dlc-manager/src/manager.rs
+++ b/dlc-manager/src/manager.rs
@@ -1647,7 +1647,7 @@ where
         }
 
         let offered_contract =
-            crate::channel_updater::on_renew_offer(&mut signed_channel, renew_offer)?;
+            crate::channel_updater::on_renew_offer(&mut signed_channel, renew_offer, PEER_TIMEOUT, &self.time)?;
 
         self.store.create_contract(&offered_contract)?;
         self.store


### PR DESCRIPTION
Otherwise the channel gets force closed immediately if the periodic check happens to run before the channel has advanced to the next state.