### PR TITLE
fix: Add timestamp to make `RenewRevoke` message unique.

### DIFF
--- a/dlc-manager/src/channel_updater.rs
+++ b/dlc-manager/src/channel_updater.rs
@@ -2092,6 +2092,7 @@ where
     let msg = RenewRevoke {
         channel_id: signed_channel.channel_id,
         per_update_secret: prev_per_update_secret,
+        timestamp: get_unix_time_now()
     };
 
     Ok(msg)

--- a/dlc-messages/src/channel.rs
+++ b/dlc-messages/src/channel.rs
@@ -530,11 +530,14 @@ pub struct RenewRevoke {
     /// The pre image of the per update point used by the sending party to setup
     /// the previous channel state.
     pub per_update_secret: SecretKey,
+    /// The timestamp when the message was created
+    pub timestamp: u64,
 }
 
 impl_dlc_writeable!(RenewRevoke, {
     (channel_id, writeable),
-    (per_update_secret, writeable)
+    (per_update_secret, writeable),
+    (timestamp, writeable)
 });
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Otherwise we would skip the message on the app layer as it has already been processed.