### PR TITLE
Enforce Rust code format on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,17 @@ jobs:
         run: rustup component add clippy
       - name: Run clippy
         run: cargo clippy -- -D warnings
+  fmt:
+    name: rustfmt-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+            components: rustfmt
+      - name: Check format
+        run: cargo fmt --all --check
   no-std:
     name: no-std lint
     runs-on: ubuntu-latest

--- a/dlc-manager/src/channel/mod.rs
+++ b/dlc-manager/src/channel/mod.rs
@@ -45,7 +45,7 @@ impl std::fmt::Debug for Channel {
             Channel::Signed(_) => "signed",
             Channel::FailedAccept(_) => "failed accept",
             Channel::FailedSign(_) => "failed sign",
-            Channel::Cancelled(_) => "cancelled"
+            Channel::Cancelled(_) => "cancelled",
         };
         f.debug_struct("Contract").field("state", &state).finish()
     }

--- a/dlc-manager/tests/channel_execution_tests.rs
+++ b/dlc-manager/tests/channel_execution_tests.rs
@@ -477,11 +477,13 @@ fn channel_execution_test(test_params: TestParams, path: TestPath) {
     assert_channel_state!(alice_manager_send, temporary_channel_id, Offered);
 
     if let TestPath::CancelOffer = path {
-        let (reject_msg, _) = alice_manager_send.lock().unwrap().reject_channel(&temporary_channel_id).expect("Error rejecting contract offer");
+        let (reject_msg, _) = alice_manager_send
+            .lock()
+            .unwrap()
+            .reject_channel(&temporary_channel_id)
+            .expect("Error rejecting contract offer");
         assert_channel_state!(alice_manager_send, temporary_channel_id, Cancelled);
-        alice_send
-            .send(Some(Message::Reject(reject_msg)))
-            .unwrap();
+        alice_send.send(Some(Message::Reject(reject_msg))).unwrap();
 
         sync_receive.recv().expect("Error synchronizing");
         assert_channel_state!(bob_manager_send, temporary_channel_id, Cancelled);

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+max_width = 100


### PR DESCRIPTION
Not too different here, but the LN-DLC channels branch that we (10101) are still based on has a lot more conflicts with `rustfmt`. I can fix that independently, but I think this is still nice.