### PR TITLE
Run generate_blocks script in docker in sample instructions

### DIFF
--- a/dlc-manager/src/chain_monitor.rs
+++ b/dlc-manager/src/chain_monitor.rs
@@ -1,4 +1,4 @@
-//!
+//! Implementation of a chain monitor to watch the blockchain for transactions of interest.
 
 use std::collections::HashMap;
 

--- a/sample/Readme.md
+++ b/sample/Readme.md
@@ -51,7 +51,7 @@ Typing the same command in Alice's instance will make Alice broadcast the fund t
 
 Now in yet another terminal (still from the same location) run:
 ```bash
-../scripts/generate_blocks.sh
+docker compose exec bitcoind /scripts/generate_blocks.sh
 ```
 
 This will generate some blocks so that the fund transaction is confirmed.
@@ -88,7 +88,7 @@ Typing the same command in Alice's instance will make Alice broadcast the fund t
 
 Now in yet another terminal (still from the same location) run:
 ```bash
-../scripts/generate_blocks.sh
+docker compose exec bitcoind /scripts/generate_blocks.sh
 ```
 
 This will generate some blocks so that the fund transaction is confirmed.


### PR DESCRIPTION
@alfonzii the updated instructions should allow you to run the scripts without having `bitcoin-cli` available locally. Can you let me know if that works for you?