### PR TITLE
chore: Update `bitcoin` to `0.31.2`

### DIFF
--- a/bitcoin-rpc-provider/Cargo.toml
+++ b/bitcoin-rpc-provider/Cargo.toml
@@ -5,12 +5,12 @@ name = "bitcoin-rpc-provider"
 version = "0.1.0"
 
 [dependencies]
-bitcoin = {version = "0.30.2"}
-bitcoincore-rpc = {version = "0.17.0"}
-bitcoincore-rpc-json = {version = "0.17.0"}
+bitcoin = {version = "0.31.2"}
+bitcoincore-rpc = {version = "0.19.0"}
+bitcoincore-rpc-json = {version = "0.19.0"}
 dlc-manager = {path = "../dlc-manager"}
 hex = { package = "hex-conservative", version = "0.1" }
-lightning = { version = "0.0.121" }
+lightning = { version = "0.0.123" }
 log = "0.4.14"
 rust-bitcoin-coin-selection = { version = "0.1.0", git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection", rev = "405451929568422f7df809e35d6ad8f36fccce90", features = ["rand"] }
 simple-wallet = {path = "../simple-wallet"}

--- a/bitcoin-test-utils/Cargo.toml
+++ b/bitcoin-test-utils/Cargo.toml
@@ -4,6 +4,6 @@ name = "bitcoin-test-utils"
 version = "0.1.0"
 
 [dependencies]
-bitcoin = { version = "0.30.2", default-features = false }
-bitcoincore-rpc = {version = "0.17"}
-bitcoincore-rpc-json = {version = "0.17"}
+bitcoin = { version = "0.31.2", default-features = false }
+bitcoincore-rpc = {version = "0.19"}
+bitcoincore-rpc-json = {version = "0.19"}

--- a/dlc-manager/Cargo.toml
+++ b/dlc-manager/Cargo.toml
@@ -17,15 +17,16 @@ use-serde = ["serde", "dlc/use-serde", "dlc-messages/serde", "dlc-trie/use-serde
 
 [dependencies]
 async-trait = "0.1.50"
-bitcoin = { version = "0.30.2", default-features = false }
+bitcoin = { version = "0.31.2", default-features = false }
 dlc = { version = "0.4.0", default-features = false, path = "../dlc" }
 dlc-messages = { version = "0.4.0", default-features = false, path = "../dlc-messages" }
 dlc-trie = { version = "0.4.0", default-features = false, path = "../dlc-trie" }
 hex = { package = "hex-conservative", version = "0.1" }
-lightning = { version = "0.0.121", default-features = false, features = ["grind_signatures"] }
+# lightning = { version = "0.0.123", default-features = false, features = ["grind_signatures"] }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "main", default-features = false, features = ["grind_signatures"] }
 log = "0.4.14"
 rand_chacha = {version = "0.3.1", optional = true}
-secp256k1-zkp = {version = "0.9.2"}
+secp256k1-zkp = {version = "0.10.1"}
 serde = {version = "1.0", optional = true}
 
 [dev-dependencies]
@@ -39,7 +40,7 @@ dlc-messages = { path = "../dlc-messages", default-features = false, features = 
 electrs-blockchain-provider = {path = "../electrs-blockchain-provider"}
 env_logger = "0.9.1"
 mocks = {path = "../mocks"}
-secp256k1-zkp = {version = "0.9.2", features = ["bitcoin_hashes", "rand", "rand-std", "global-context", "serde"]}
+secp256k1-zkp = {version = "0.10.1", features = ["rand", "rand-std", "global-context", "serde"]}
 serde = "1.0"
 serde_json = "1.0"
 simple-wallet = {path = "../simple-wallet"}

--- a/dlc-manager/src/channel_updater.rs
+++ b/dlc-manager/src/channel_updater.rs
@@ -225,7 +225,7 @@ where
     let buffer_adaptor_signature = get_tx_adaptor_signature(
         secp,
         &buffer_transaction,
-        dlc_transactions.get_fund_output().value,
+        dlc_transactions.get_fund_output().value.to_sat(),
         &dlc_transactions.funding_script_pubkey,
         &signer.get_secret_key()?,
         &offer_revoke_params.publish_pk.inner,
@@ -237,7 +237,7 @@ where
         &accept_params,
         &funding_inputs,
         &own_secret_key,
-        buffer_transaction.output[0].value,
+        buffer_transaction.output[0].value.to_sat(),
         Some(&buffer_script_pubkey),
         &dlc_transactions,
     )?;
@@ -359,7 +359,7 @@ where
         &accept_channel.funding_inputs,
         &accept_channel.refund_signature,
         &accept_cet_adaptor_signatures,
-        buffer_transaction.output[0].value,
+        buffer_transaction.output[0].value.to_sat(),
         wallet,
         &offer_own_sk,
         Some(&buffer_script_pubkey),
@@ -371,7 +371,7 @@ where
     verify_tx_adaptor_signature(
         secp,
         &buffer_transaction,
-        dlc_transactions.get_fund_output().value,
+        dlc_transactions.get_fund_output().value.to_sat(),
         &dlc_transactions.funding_script_pubkey,
         &signed_contract.accepted_contract.accept_params.fund_pubkey,
         &offer_revoke_params.publish_pk.inner,
@@ -381,7 +381,7 @@ where
     let own_buffer_adaptor_signature = get_tx_adaptor_signature(
         secp,
         &buffer_transaction,
-        dlc_transactions.get_fund_output().value,
+        dlc_transactions.get_fund_output().value.to_sat(),
         &dlc_transactions.funding_script_pubkey,
         &offer_fund_sk.get_secret_key()?,
         &accept_revoke_params.publish_pk.inner,
@@ -457,7 +457,7 @@ where
     verify_tx_adaptor_signature(
         secp,
         &accepted_channel.buffer_transaction,
-        accepted_contract.dlc_transactions.get_fund_output().value,
+        accepted_contract.dlc_transactions.get_fund_output().value.to_sat(),
         &accepted_contract.dlc_transactions.funding_script_pubkey,
         &accepted_contract.offered_contract.offer_params.fund_pubkey,
         &own_publish_pk,
@@ -472,7 +472,7 @@ where
         &sign_channel.refund_signature,
         &cet_adaptor_signatures,
         &sign_channel.funding_signatures,
-        accepted_channel.buffer_transaction.output[0].value,
+        accepted_channel.buffer_transaction.output[0].value.to_sat(),
         Some(&accepted_channel.buffer_script_pubkey),
         Some(counter_own_pk),
         wallet,
@@ -840,7 +840,7 @@ where
     verify_tx_adaptor_signature(
         secp,
         settle_tx,
-        channel.fund_tx.output[channel.fund_output_index].value,
+        channel.fund_tx.output[channel.fund_output_index].value.to_sat(),
         &channel.fund_script_pubkey,
         &channel.counter_params.fund_pubkey,
         &accept_revoke_params.publish_pk.inner,
@@ -1190,7 +1190,7 @@ where
     let buffer_adaptor_signature = get_tx_adaptor_signature(
         secp,
         &buffer_transaction,
-        dlc_transactions.get_fund_output().value,
+        dlc_transactions.get_fund_output().value.to_sat(),
         &dlc_transactions.funding_script_pubkey,
         &contract_signer.get_secret_key()?,
         &offer_revoke_params.publish_pk.inner,
@@ -1204,7 +1204,7 @@ where
         &signed_channel.own_params,
         &[],
         &own_secret_key,
-        buffer_transaction.output[0].value,
+        buffer_transaction.output[0].value.to_sat(),
         Some(&buffer_script_pubkey),
         &dlc_transactions,
     )?;
@@ -1318,7 +1318,7 @@ where
         &[],
         &renew_accept.refund_signature,
         &cet_adaptor_signatures,
-        buffer_transaction.output[0].value,
+        buffer_transaction.output[0].value.to_sat(),
         wallet,
         &offer_own_sk,
         Some(&buffer_script_pubkey),
@@ -1330,7 +1330,7 @@ where
     verify_tx_adaptor_signature(
         secp,
         &buffer_transaction,
-        dlc_transactions.get_fund_output().value,
+        dlc_transactions.get_fund_output().value.to_sat(),
         &dlc_transactions.funding_script_pubkey,
         &signed_contract.accepted_contract.accept_params.fund_pubkey,
         &offer_revoke_params.publish_pk.inner,
@@ -1340,7 +1340,7 @@ where
     let own_buffer_adaptor_signature = get_tx_adaptor_signature(
         secp,
         &buffer_transaction,
-        dlc_transactions.get_fund_output().value,
+        dlc_transactions.get_fund_output().value.to_sat(),
         &dlc_transactions.funding_script_pubkey,
         &contract_signer.get_secret_key()?,
         &accept_revoke_params.publish_pk.inner,
@@ -1416,7 +1416,7 @@ where
     verify_tx_adaptor_signature(
         secp,
         buffer_transaction,
-        accepted_contract.dlc_transactions.get_fund_output().value,
+        accepted_contract.dlc_transactions.get_fund_output().value.to_sat(),
         &accepted_contract.dlc_transactions.funding_script_pubkey,
         &accepted_contract.offered_contract.offer_params.fund_pubkey,
         &own_publish_pk,
@@ -1431,7 +1431,7 @@ where
         &FundingSignatures {
             funding_signatures: Vec::new(),
         },
-        buffer_transaction.output[0].value,
+        buffer_transaction.output[0].value.to_sat(),
         Some(buffer_script_pubkey),
         Some(counter_own_pk),
         wallet,
@@ -1573,7 +1573,7 @@ where
     let total_collateral =
         signed_channel.own_params.collateral + signed_channel.counter_params.collateral;
     let offer_payout = total_collateral - counter_payout;
-    let fund_output_value = signed_channel.fund_tx.output[signed_channel.fund_output_index].value;
+    let fund_output_value = signed_channel.fund_tx.output[signed_channel.fund_output_index].value.to_sat();
 
     let close_tx = dlc::channel::create_collaborative_close_transaction(
         &signed_channel.own_params,
@@ -1648,7 +1648,7 @@ where
     }
 
     let offer_payout = total_collateral - close_offer.counter_payout;
-    let fund_output_value = signed_channel.fund_tx.output[signed_channel.fund_output_index].value;
+    let fund_output_value = signed_channel.fund_tx.output[signed_channel.fund_output_index].value.to_sat();
 
     let close_tx = dlc::channel::create_collaborative_close_transaction(
         &signed_channel.counter_params,
@@ -1695,7 +1695,7 @@ where
         keys_id
     )?;
 
-    let fund_out_amount = signed_channel.fund_tx.output[signed_channel.fund_output_index].value;
+    let fund_out_amount = signed_channel.fund_tx.output[signed_channel.fund_output_index].value.to_sat();
 
     let contract_signer = signer_provider.derive_contract_signer(*keys_id)?;
 
@@ -1771,7 +1771,7 @@ fn get_settle_tx_and_adaptor_sig(
         accept_payout,
         csv_timelock,
         lock_time,
-        fund_tx.output[fund_vout].value,
+        fund_tx.output[fund_vout].value.to_sat(),
         fee_rate_per_vb,
     )?;
 
@@ -1779,7 +1779,7 @@ fn get_settle_tx_and_adaptor_sig(
         verify_tx_adaptor_signature(
             secp,
             &settle_tx,
-            fund_tx.output[fund_vout].value,
+            fund_tx.output[fund_vout].value.to_sat(),
             funding_script_pubkey,
             &fund_pk,
             &offer_revoke_params.publish_pk.inner,
@@ -1796,7 +1796,7 @@ fn get_settle_tx_and_adaptor_sig(
     let settle_adaptor_signature = dlc::channel::get_tx_adaptor_signature(
         secp,
         &settle_tx,
-        fund_tx.output[fund_vout].value,
+        fund_tx.output[fund_vout].value.to_sat(),
         funding_script_pubkey,
         own_fund_sk,
         &counter_pk,
@@ -1878,7 +1878,7 @@ where
         &signed_channel.counter_params.fund_pubkey,
         &fund_sk.get_secret_key()?,
         &signed_channel.fund_script_pubkey,
-        signed_channel.fund_tx.output[signed_channel.fund_output_index].value,
+        signed_channel.fund_tx.output[signed_channel.fund_output_index].value.to_sat(),
         0,
     )?;
 
@@ -1951,7 +1951,7 @@ where
     dlc::channel::sign_cet(
         secp,
         &mut cet,
-        buffer_transaction.output[0].value,
+        buffer_transaction.output[0].value.to_sat(),
         &offer_revoke_params,
         &accept_revoke_params,
         &own_sk,
@@ -2009,7 +2009,7 @@ where
         &signed_channel.counter_params.fund_pubkey,
         &fund_sk.get_secret_key()?,
         &signed_channel.fund_script_pubkey,
-        signed_channel.fund_tx.output[signed_channel.fund_output_index].value,
+        signed_channel.fund_tx.output[signed_channel.fund_output_index].value.to_sat(),
         0,
     )?;
 

--- a/dlc-manager/src/contract/accepted_contract.rs
+++ b/dlc-manager/src/contract/accepted_contract.rs
@@ -89,7 +89,7 @@ impl AcceptedContract {
             .iter()
             .find_map(|x| {
                 if &x.script_pubkey == v0_witness_payout_script {
-                    Some(x.value)
+                    Some(x.value.to_sat())
                 } else {
                     None
                 }

--- a/dlc-manager/src/conversion_utils.rs
+++ b/dlc-manager/src/conversion_utils.rs
@@ -82,7 +82,7 @@ pub fn get_tx_input_infos(
             .output
             .get(vout as usize)
             .ok_or(Error::InvalidParameters)?;
-        input_amount += tx_out.value;
+        input_amount += tx_out.value.to_sat();
         inputs.push(TxInputInfo {
             outpoint: OutPoint {
                 txid: tx.txid(),

--- a/dlc-manager/src/error.rs
+++ b/dlc-manager/src/error.rs
@@ -25,6 +25,8 @@ pub enum Error {
     DlcError(dlc::Error),
     /// An error occurred in the Secp library.
     SecpError(secp256k1_zkp::Error),
+    /// An error occured extracting a PSBT.
+    ExtractPsbt(bitcoin::psbt::ExtractTxError)
 }
 
 impl fmt::Display for Error {
@@ -40,6 +42,7 @@ impl fmt::Display for Error {
             Error::DlcError(ref e) => write!(f, "Dlc error {}", e),
             Error::OracleError(ref s) => write!(f, "Oracle error {}", s),
             Error::SecpError(_) => write!(f, "Secp error"),
+            Error::ExtractPsbt(_) => write!(f, "PSBT error"),
         }
     }
 }
@@ -74,6 +77,12 @@ impl From<secp256k1_zkp::UpstreamError> for Error {
     }
 }
 
+impl From<bitcoin::psbt::ExtractTxError> for Error {
+    fn from(e: bitcoin::psbt::ExtractTxError) -> Self {
+        Error::ExtractPsbt(e)
+    }
+}
+
 #[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
@@ -88,6 +97,7 @@ impl std::error::Error for Error {
             Error::OracleError(_) => None,
             Error::DlcError(e) => Some(e),
             Error::SecpError(e) => Some(e),
+            Error::ExtractPsbt(e) => Some(e)
         }
     }
 }

--- a/dlc-manager/src/lib.rs
+++ b/dlc-manager/src/lib.rs
@@ -36,7 +36,7 @@ pub mod manager;
 pub mod payout_curve;
 mod utils;
 
-use bitcoin::psbt::PartiallySignedTransaction;
+use bitcoin::psbt::Psbt;
 use bitcoin::{Address, Block, OutPoint, ScriptBuf, Transaction, TxOut, Txid};
 use chain_monitor::ChainMonitor;
 use channel::offered_channel::OfferedChannel;
@@ -164,7 +164,7 @@ pub trait Wallet {
     /// Signs a transaction input
     fn sign_psbt_input(
         &self,
-        psbt: &mut PartiallySignedTransaction,
+        psbt: &mut Psbt,
         input_index: usize,
     ) -> Result<(), Error>;
     /// Unlock reserved utxo
@@ -176,7 +176,7 @@ pub trait Blockchain {
     /// Broadcast the given transaction to the bitcoin network.
     fn send_transaction(&self, transaction: &Transaction) -> Result<(), Error>;
     /// Returns the network currently used (mainnet, testnet or regtest).
-    fn get_network(&self) -> Result<bitcoin::network::constants::Network, Error>;
+    fn get_network(&self) -> Result<bitcoin::Network, Error>;
     /// Returns the height of the blockchain
     fn get_blockchain_height(&self) -> Result<u64, Error>;
     /// Returns the block at given height

--- a/dlc-manager/src/utils.rs
+++ b/dlc-manager/src/utils.rs
@@ -104,7 +104,7 @@ where
             max_witness_len,
             redeem_script: utxo.redeem_script,
         };
-        total_input += prev_tx.output[prev_tx_vout as usize].value;
+        total_input += prev_tx.output[prev_tx_vout as usize].value.to_sat();
         funding_tx_info.push((&funding_input).into());
         funding_inputs.push(funding_input);
     }

--- a/dlc-messages/Cargo.toml
+++ b/dlc-messages/Cargo.toml
@@ -10,19 +10,20 @@ version = "0.4.0"
 [features]
 default = ["std"]
 std = ["dlc/std", "bitcoin/std", "lightning/std"]
-no-std = ["bitcoin/no-std", "dlc/no-std", "lightning/no-std"]
+no-std = ["dlc/no-std", "lightning/no-std"]
 use-serde = ["serde", "secp256k1-zkp/serde", "bitcoin/serde"]
 
 [dependencies]
-bitcoin = { version = "0.30.2", default-features = false }
+bitcoin = { version = "0.31.2", default-features = false }
 dlc = { version = "0.4.0", path = "../dlc", default-features = false }
-lightning = { version = "0.0.121", default-features = false }
-secp256k1-zkp = {version = "0.9.2"}
+# lightning = { version = "0.0.123", default-features = false }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "main", default-features = false }
+secp256k1-zkp = {version = "0.10.1"}
 serde = {version = "1.0", features = ["derive"], optional = true}
 
 [dev-dependencies]
 bitcoin = { version = "0.30.2", default-features = false, features = ["serde"] }
 dlc-messages = {path = "./", default-features = false, features = ["use-serde"]}
-secp256k1-zkp = {version = "0.9.2", features = ["serde", "global-context"]}
+secp256k1-zkp = {version = "0.10.1", features = ["serde", "global-context"]}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"

--- a/dlc-messages/src/ser_impls.rs
+++ b/dlc-messages/src/ser_impls.rs
@@ -1,6 +1,6 @@
 //! Set of utility functions to help with serialization.
 
-use bitcoin::network::constants::Network;
+use bitcoin::Network;
 use bitcoin::Address;
 use dlc::{EnumerationPayout, PartyParams, Payout, TxInputInfo};
 use lightning::io::Read;
@@ -478,7 +478,7 @@ pub fn write_address<W: Writer>(
     writer: &mut W,
 ) -> Result<(), ::lightning::io::Error> {
     address.script_pubkey().write(writer)?;
-    let net: u8 = match address.network {
+    let net: u8 = match address.network() {
         Network::Bitcoin => 0,
         Network::Testnet => 1,
         Network::Signet => 2,

--- a/dlc-sled-storage-provider/Cargo.toml
+++ b/dlc-sled-storage-provider/Cargo.toml
@@ -12,9 +12,10 @@ version = "0.1.0"
 wallet = ["bitcoin", "secp256k1-zkp", "simple-wallet", "lightning"]
 
 [dependencies]
-bitcoin = {version = "0.30", optional = true}
+bitcoin = {version = "0.31.2", optional = true}
 dlc-manager = {path = "../dlc-manager"}
-lightning = {version = "0.0.121", optional = true}
-secp256k1-zkp = {version = "0.9", optional = true}
+# lightning = {version = "0.0.123", optional = true}
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "main", default-features = false, optional = true }
+secp256k1-zkp = {version = "0.10.1", optional = true}
 simple-wallet = {path = "../simple-wallet", optional = true}
 sled = "0.34"

--- a/dlc-trie/Cargo.toml
+++ b/dlc-trie/Cargo.toml
@@ -10,13 +10,13 @@ version = "0.4.0"
 [features]
 default = ["std"]
 std = ["dlc/std", "bitcoin/std"]
-no-std = ["bitcoin/no-std", "dlc/no-std"]
+no-std = ["dlc/no-std"]
 parallel = ["rayon"]
 use-serde = ["serde", "dlc/use-serde"]
 
 [dependencies]
-bitcoin = { version = "0.30.2", default-features = false }
+bitcoin = { version = "0.31.2", default-features = false }
 dlc = {version = "0.4.0", default-features = false, path = "../dlc"}
 rayon = {version = "1.5", optional = true}
-secp256k1-zkp = {version = "0.9.2" }
+secp256k1-zkp = {version = "0.10.1" }
 serde = {version = "1.0", optional = true, default_features = false, features = ["derive"]}

--- a/dlc/Cargo.toml
+++ b/dlc/Cargo.toml
@@ -8,11 +8,11 @@ repository = "https://github.com/p2pderivatives/rust-dlc/tree/master/dlc"
 version = "0.4.0"
 
 [dependencies]
-bitcoin = { version = "0.30.2", default-features = false }
+bitcoin = { version = "0.31.2", default-features = false }
 hashbrown = { version = "0.11.2", optional = true }
-miniscript = { version = "10", default-features = false }
-secp256k1-sys = "0.8.1"
-secp256k1-zkp = "0.9.2"
+miniscript = { version = "11", default-features = false }
+secp256k1-sys = "0.10.0"
+secp256k1-zkp = "0.10.1"
 serde = { version = "1.0", default-features = false, optional = true }
 
 [features]
@@ -20,7 +20,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 unstable = []
 default = ["std"]
 std = ["bitcoin/std", "miniscript/std", "secp256k1-zkp/rand-std"]
-no-std = ["dep:hashbrown", "miniscript/no-std", "bitcoin/no-std"]
+no-std = ["dep:hashbrown", "miniscript/no-std"]
 use-serde = ["serde", "secp256k1-zkp/serde", "bitcoin/serde"]
 
 [dev-dependencies]
@@ -28,4 +28,4 @@ bitcoin-test-utils = { path = "../bitcoin-test-utils" }
 bitcoincore-rpc = { version = "0.17.0" }
 bitcoincore-rpc-json = { version = "0.17.0" }
 rayon = "1.5"
-secp256k1-zkp = { version = "0.9.2", features = ["bitcoin_hashes", "rand","serde", "global-context"] }
+secp256k1-zkp = { version = "0.10.1", features = ["rand", "serde", "global-context"] }

--- a/dlc/src/secp_utils.rs
+++ b/dlc/src/secp_utils.rs
@@ -3,36 +3,35 @@
 
 use crate::Error;
 use core::ptr;
-use secp256k1_sys::{
-    types::{c_int, c_uchar, c_void, size_t},
-    CPtr, SchnorrSigExtraParams,
-};
-use secp256k1_zkp::hashes::Hash;
+use secp256k1_sys::types::{c_int, c_uchar, c_void, size_t};
+use secp256k1_zkp::secp256k1_zkp_sys::CPtr;
+// use secp256k1_zkp::hashes::Hash;
+// use bitcoin::hashes::sha256t_hash_newtype;
 use secp256k1_zkp::hashes::*;
 use secp256k1_zkp::{
-    schnorr::Signature as SchnorrSignature, KeyPair, Message, PublicKey, Scalar, Secp256k1,
-    Signing, Verification, XOnlyPublicKey,
+    schnorr::Signature as SchnorrSignature, Message, PublicKey, Scalar, Secp256k1,
+    Signing, Verification, XOnlyPublicKey, secp256k1_zkp_sys::{Keypair, SchnorrSigExtraParams}, 
 };
 
-const BIP340_MIDSTATE: [u8; 32] = [
-    0x9c, 0xec, 0xba, 0x11, 0x23, 0x92, 0x53, 0x81, 0x11, 0x67, 0x91, 0x12, 0xd1, 0x62, 0x7e, 0x0f,
-    0x97, 0xc8, 0x75, 0x50, 0x00, 0x3c, 0xc7, 0x65, 0x90, 0xf6, 0x11, 0x64, 0x33, 0xe9, 0xb6, 0x6a,
-];
+// const BIP340_MIDSTATE: [u8; 32] = [
+//     0x9c, 0xec, 0xba, 0x11, 0x23, 0x92, 0x53, 0x81, 0x11, 0x67, 0x91, 0x12, 0xd1, 0x62, 0x7e, 0x0f,
+//     0x97, 0xc8, 0x75, 0x50, 0x00, 0x3c, 0xc7, 0x65, 0x90, 0xf6, 0x11, 0x64, 0x33, 0xe9, 0xb6, 0x6a,
+// ];
 
-sha256t_hash_newtype!(
-    BIP340Hash,
-    BIP340HashTag,
-    BIP340_MIDSTATE,
-    64,
-    doc = "bip340 hash",
-    backward
-);
+sha256t_hash_newtype! {
+    /// BIP340 Hash Tag
+    pub struct BIP340HashTag = hash_str("bip340 hash");
 
+    /// BIP340 Hash
+    #[hash_newtype(backward)]
+    pub struct BIP340Hash(_);
+
+}
 /// Create a Schnorr signature using the provided nonce instead of generating one.
 pub fn schnorrsig_sign_with_nonce<S: Signing>(
     secp: &Secp256k1<S>,
     msg: &Message,
-    keypair: &KeyPair,
+    keypair: &Keypair,
     nonce: &[u8; 32],
 ) -> SchnorrSignature {
     unsafe {
@@ -41,12 +40,12 @@ pub fn schnorrsig_sign_with_nonce<S: Signing>(
             SchnorrSigExtraParams::new(Some(constant_nonce_fn), nonce.as_c_ptr() as *const c_void);
         assert_eq!(
             1,
-            secp256k1_sys::secp256k1_schnorrsig_sign_custom(
+            secp256k1_zkp::secp256k1_zkp_sys::secp256k1_schnorrsig_sign_custom(
                 secp.ctx().as_ref(),
                 sig.as_mut_c_ptr(),
                 msg.as_c_ptr(),
                 32_usize,
-                keypair.as_c_ptr(),
+                keypair,
                 &extra_params,
             )
         );

--- a/electrs-blockchain-provider/Cargo.toml
+++ b/electrs-blockchain-provider/Cargo.toml
@@ -6,10 +6,10 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = {version = "0.30"}
+bitcoin = {version = "0.31.2"}
 bitcoin-test-utils = {path = "../bitcoin-test-utils"}
 dlc-manager = {path = "../dlc-manager"}
-lightning = {version = "0.0.121"}
+lightning = {version = "0.0.123"}
 lightning-block-sync = {version = "0.0.121"}
 reqwest = {version = "0.11", features = ["blocking", "json"]}
 serde = {version = "*", features = ["derive"]}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 dlc-messages = {path = "../dlc-messages"}
 honggfuzz = "0.5"
-lightning = {version = "0.0.121" }
+lightning = {version = "0.0.123" }
 
 [workspace]
 members = ["."]

--- a/mocks/Cargo.toml
+++ b/mocks/Cargo.toml
@@ -5,10 +5,10 @@ name = "mocks"
 version = "0.1.0"
 
 [dependencies]
-bitcoin = "0.30"
+bitcoin = "0.31.2"
 dlc = {path = "../dlc"}
 dlc-manager = {path = "../dlc-manager"}
 dlc-messages = {path = "../dlc-messages"}
-lightning = {version = "0.0.121"}
-secp256k1-zkp = {version = "0.9.2", features = ["bitcoin_hashes", "global-context", "rand", "rand-std"]}
+lightning = {version = "0.0.123"}
+secp256k1-zkp = {version = "0.10.1", features = ["global-context", "rand", "rand-std"]}
 simple-wallet = {path = "../simple-wallet"}

--- a/p2pd-oracle-client/Cargo.toml
+++ b/p2pd-oracle-client/Cargo.toml
@@ -12,7 +12,7 @@ chrono = {version = "0.4.19", features = ["serde"]}
 dlc-manager = {path = "../dlc-manager"}
 dlc-messages = {path = "../dlc-messages", features = ["use-serde"]}
 reqwest = {version = "0.11", features = ["blocking", "json"]}
-secp256k1-zkp = {version = "0.9.2" }
+secp256k1-zkp = {version = "0.10.1" }
 serde = {version = "*", features = ["derive"]}
 
 [dev-dependencies]

--- a/sample/Cargo.toml
+++ b/sample/Cargo.toml
@@ -5,14 +5,14 @@ name = "sample"
 version = "0.1.0"
 
 [dependencies]
-bitcoin = {version = "0.30.2"}
+bitcoin = {version = "0.31.2"}
 bitcoin-rpc-provider = {path = "../bitcoin-rpc-provider"}
-dlc = {path = "../dlc", features = ["use-serde"]}
+dlc = {version = "0.4.0", path = "../dlc", features = ["use-serde"]}
 dlc-manager = {path = "../dlc-manager", features = ["use-serde", "parallel"]}
 dlc-messages = {path = "../dlc-messages"}
 dlc-sled-storage-provider = {path = "../dlc-sled-storage-provider"}
 futures = "0.3"
-lightning = {version = "0.0.121"}
+lightning = {version = "0.0.123"}
 lightning-net-tokio = {version = "0.0.121" }
 p2pd-oracle-client = {path = "../p2pd-oracle-client"}
 serde = "1.0"

--- a/simple-wallet/Cargo.toml
+++ b/simple-wallet/Cargo.toml
@@ -6,13 +6,14 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = "0.30"
+bitcoin = "0.31.2"
 dlc = {path = "../dlc"}
 dlc-manager = {path = "../dlc-manager"}
-lightning = {version = "0.0.121"}
+# lightning = {version = "0.0.121"}
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "main" }
 bdk = {version = "0.29.0"}
-secp256k1-zkp = {version = "0.9.2"}
+secp256k1-zkp = {version = "0.10.1"}
 
 [dev-dependencies]
 mocks = {path = "../mocks"}
-secp256k1-zkp = {version = "0.9.2", features = ["global-context"]}
+secp256k1-zkp = {version = "0.10.1", features = ["global-context"]}


### PR DESCRIPTION
`bdk@1.0.0` uses `bitcoin@0.31.2`

Peer dependencies of `secp256k1_(zkp,sys)` are updated as well to match `secp256k1@0.28` that is used in `0.32.1`

`lightning@0.0.123` still uses `0.30` but has been merged into `main`.

Leaving this branch as draft until it is in a `lightning` release and to convert `simple-wallet` to `bdk@1.0.0`