### PR TITLE
chore: use correct feature name for serde

### DIFF
--- a/dlc-manager/Cargo.toml
+++ b/dlc-manager/Cargo.toml
@@ -13,7 +13,7 @@ default = ["std"]
 std = ["dlc/std", "dlc-messages/std", "dlc-trie/std", "bitcoin/std", "lightning/std"]
 fuzztarget = ["rand_chacha"]
 parallel = ["dlc-trie/parallel"]
-use-serde = ["serde", "dlc/use-serde", "dlc-messages/serde", "dlc-trie/use-serde"]
+use-serde = ["serde", "dlc/use-serde", "dlc-messages/use-serde", "dlc-trie/use-serde"]
 
 [dependencies]
 async-trait = "0.1.50"

--- a/dlc-manager/src/channel/offered_channel.rs
+++ b/dlc-manager/src/channel/offered_channel.rs
@@ -15,7 +15,7 @@ use super::party_points::PartyBasePoints;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-manager/src/channel/party_points.rs
+++ b/dlc-manager/src/channel/party_points.rs
@@ -11,7 +11,7 @@ use secp256k1_zkp::{All, PublicKey, Secp256k1, Signing, Verification};
 /// values necessary for state update throughout the lifetime of the channel.
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-manager/src/contract/contract_info.rs
+++ b/dlc-manager/src/contract/contract_info.rs
@@ -19,7 +19,7 @@ pub(super) type OracleIndexAndPrefixLength = Vec<(usize, usize)>;
 /// Contains information about the contract conditions and oracles used.
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-manager/src/contract/contract_input.rs
+++ b/dlc-manager/src/contract/contract_input.rs
@@ -4,13 +4,13 @@ use crate::error::Error;
 
 use super::ContractDescriptor;
 use secp256k1_zkp::XOnlyPublicKey;
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 use serde::{Deserialize, Serialize};
 
 /// Oracle information required for the initial creation of a contract.
 #[derive(Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -53,7 +53,7 @@ impl OracleInput {
 /// Represents the contract specifications.
 #[derive(Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -66,7 +66,7 @@ pub struct ContractInputInfo {
 
 #[derive(Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-manager/src/contract/enum_descriptor.rs
+++ b/dlc-manager/src/contract/enum_descriptor.rs
@@ -12,13 +12,13 @@ use dlc_trie::{combination_iterator::CombinationIterator, RangeInfo};
 use secp256k1_zkp::{
     All, EcdsaAdaptorSignature, Message, PublicKey, Secp256k1, SecretKey, Verification,
 };
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 use serde::{Deserialize, Serialize};
 
 /// A descriptor for a contract whose outcomes are represented as an enumeration.
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-manager/src/contract/mod.rs
+++ b/dlc-manager/src/contract/mod.rs
@@ -10,7 +10,7 @@ use dlc_messages::{
 use dlc_trie::multi_oracle_trie::MultiOracleTrie;
 use dlc_trie::multi_oracle_trie_with_diff::MultiOracleTrieWithDiff;
 use secp256k1_zkp::PublicKey;
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 use serde::{Deserialize, Serialize};
 use signed_contract::SignedContract;
 
@@ -188,7 +188,7 @@ pub enum AdaptorInfo {
 /// The descriptor of a contract.
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-manager/src/contract/numerical_descriptor.rs
+++ b/dlc-manager/src/contract/numerical_descriptor.rs
@@ -9,13 +9,13 @@ use dlc_trie::multi_oracle_trie::MultiOracleTrie;
 use dlc_trie::multi_oracle_trie_with_diff::MultiOracleTrieWithDiff;
 use dlc_trie::{DlcTrie, OracleNumericInfo};
 use secp256k1_zkp::{All, EcdsaAdaptorSignature, PublicKey, Secp256k1, SecretKey};
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 use serde::{Deserialize, Serialize};
 
 /// Information about the allowed deviation in outcome value between the oracles.
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -33,7 +33,7 @@ pub struct DifferenceParams {
 
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-manager/src/contract/offered_contract.rs
+++ b/dlc-manager/src/contract/offered_contract.rs
@@ -17,7 +17,7 @@ use secp256k1_zkp::PublicKey;
 /// Contains information about a contract that was offered.
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-manager/src/payout_curve.rs
+++ b/dlc-manager/src/payout_curve.rs
@@ -4,13 +4,13 @@ use std::ops::Deref;
 
 use crate::error::Error;
 use dlc::{Payout, RangePayout};
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 use serde::{Deserialize, Serialize};
 
 /// Contains information to compute the set of payouts based on the outcomes.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -112,7 +112,7 @@ impl PayoutFunction {
 /// A piece of a payout function.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -274,7 +274,7 @@ where
 /// A function piece represented by a polynomial.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -373,7 +373,7 @@ impl Evaluable for PolynomialPayoutCurvePiece {
 /// A payout point representing a payout for a given outcome.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -395,7 +395,7 @@ impl PayoutPoint {
 /// A function piece represented by a hyperbola.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -487,7 +487,7 @@ impl Evaluable for HyperbolaPayoutCurvePiece {
 /// of 1 indicates that no rounding is performed.
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -501,7 +501,7 @@ pub struct RoundingInterval {
 /// A set of rounding intervals.
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-manager/tests/manager_execution_tests.rs
+++ b/dlc-manager/tests/manager_execution_tests.rs
@@ -39,7 +39,7 @@ use std::thread;
 struct TestVectorPart<T> {
     message: T,
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "dlc_messages::serde_utils::serialize_hex",
             deserialize_with = "dlc_messages::serde_utils::deserialize_hex_string"

--- a/dlc-messages/src/channel.rs
+++ b/dlc-messages/src/channel.rs
@@ -20,7 +20,7 @@ use crate::{
 /// to create a set of transactions representing the contract and its terms.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -31,7 +31,7 @@ pub struct OfferChannel {
     pub contract_flags: u8,
     /// The identifier of the chain on which the contract takes place.
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -146,13 +146,13 @@ impl OfferChannel {
 /// party that they can safely provide signatures for their funding input.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 pub struct AcceptChannel {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -214,14 +214,14 @@ impl_dlc_writeable!(AcceptChannel, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to finalize the setup of a DLC channel.
 pub struct SignChannel {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -250,14 +250,14 @@ impl_dlc_writeable!(SignChannel, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to offer a settlement of the channel by on of the parties.
 pub struct SettleOffer {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -280,14 +280,14 @@ impl_dlc_writeable!(SettleOffer, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to accept a previously received settlement offer.
 pub struct SettleAccept {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -311,14 +311,14 @@ impl_dlc_writeable!(SettleAccept, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to confirm the settlement of a channel.
 pub struct SettleConfirm {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -342,14 +342,14 @@ impl_dlc_writeable!(SettleConfirm, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to finalize the settlement of a channel.
 pub struct SettleFinalize {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -369,14 +369,14 @@ impl_dlc_writeable!(SettleFinalize, {
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to offer to establish a new contract within the channel.
 pub struct RenewOffer {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -415,14 +415,14 @@ impl_dlc_writeable!(RenewOffer, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to accept the establishment of a new contract within a channel.
 pub struct RenewAccept {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -452,14 +452,14 @@ impl_dlc_writeable!(RenewAccept, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to confirm the establishment of a new contract within a channel.
 pub struct RenewConfirm {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -489,14 +489,14 @@ impl_dlc_writeable!(RenewConfirm, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to finalize the establishment of a new contract within a channel.
 pub struct RenewFinalize {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -516,14 +516,14 @@ impl_dlc_writeable!(RenewFinalize, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Message used to offer to collaboratively close a channel.
 pub struct CollaborativeCloseOffer {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -545,7 +545,7 @@ impl_dlc_writeable!(CollaborativeCloseOffer, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -553,7 +553,7 @@ impl_dlc_writeable!(CollaborativeCloseOffer, {
 /// Message used to reject an received offer.
 pub struct Reject {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"

--- a/dlc-messages/src/contract_msgs.rs
+++ b/dlc-messages/src/contract_msgs.rs
@@ -6,7 +6,7 @@ use oracle_msgs::OracleInfo;
 
 #[derive(Clone, PartialEq, Debug, Eq)]
 #[cfg_attr(
-    any(test, feature = "serde"),
+    any(test, feature = "use-serde"),
     derive(serde::Deserialize, serde::Serialize),
     serde(rename_all = "camelCase")
 )]
@@ -23,7 +23,7 @@ impl_dlc_writeable!(ContractOutcome, {(outcome, string), (offer_payout, writeabl
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -67,7 +67,7 @@ impl ContractInfo {
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -84,7 +84,7 @@ impl_dlc_writeable!(SingleContractInfo, { (total_collateral, writeable), (contra
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -100,7 +100,7 @@ impl_dlc_writeable!(DisjointContractInfo, { (total_collateral, writeable), (cont
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -116,7 +116,7 @@ impl_dlc_writeable!(ContractInfoInner, { (contract_descriptor, writeable), (orac
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -134,7 +134,7 @@ impl_dlc_writeable_enum!(
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -149,7 +149,7 @@ impl_dlc_writeable!(EnumeratedContractDescriptor, { (payouts, vec) });
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -168,7 +168,7 @@ impl_dlc_writeable!(NumericOutcomeContractDescriptor, { (num_digits, writeable),
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -184,7 +184,7 @@ impl_dlc_writeable!(PayoutFunction, {(payout_function_pieces, vec), (last_endpoi
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -200,7 +200,7 @@ impl_dlc_writeable!(PayoutFunctionPiece, { (end_point, writeable), (payout_curve
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -219,7 +219,7 @@ impl_dlc_writeable_enum!(PayoutCurvePiece,
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -233,7 +233,7 @@ impl_dlc_writeable!(PolynomialPayoutCurvePiece, { (payout_points, vec) });
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -251,7 +251,7 @@ impl_dlc_writeable!(PayoutPoint, { (event_outcome, writeable), (outcome_payout, 
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -286,7 +286,7 @@ impl_dlc_writeable!(HyperbolaPayoutCurvePiece, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -303,7 +303,7 @@ impl_dlc_writeable!(RoundingInterval, { (begin_interval, writeable), (rounding_m
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc-messages/src/lib.rs
+++ b/dlc-messages/src/lib.rs
@@ -18,7 +18,7 @@ extern crate secp256k1_zkp;
 pub mod ser_macros;
 pub mod ser_impls;
 
-#[cfg(any(test, feature = "serde"))]
+#[cfg(any(test, feature = "use-serde"))]
 extern crate serde;
 
 #[cfg(test)]
@@ -30,7 +30,7 @@ pub mod message_handler;
 pub mod oracle_msgs;
 pub mod segmentation;
 
-#[cfg(any(test, feature = "serde"))]
+#[cfg(any(test, feature = "use-serde"))]
 pub mod serde_utils;
 
 use std::fmt::Display;
@@ -88,7 +88,7 @@ impl_type!(REJECT, Reject, 43024);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -98,7 +98,7 @@ pub struct FundingInput {
     /// Serial id used for input ordering in the funding transaction.
     pub input_serial_id: u64,
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_string"
@@ -143,7 +143,7 @@ impl From<&FundingInput> for TxInputInfo {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -159,7 +159,7 @@ impl_dlc_writeable!(CetAdaptorSignature, {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -194,7 +194,7 @@ impl_dlc_writeable!(CetAdaptorSignatures, { (ecdsa_adaptor_signatures, vec) });
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -208,7 +208,7 @@ impl_dlc_writeable!(FundingSignature, { (witness_elements, vec) });
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -223,14 +223,14 @@ impl_dlc_writeable!(FundingSignatures, { (funding_signatures, vec) });
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 /// Contains serialized data representing a single witness stack element.
 pub struct WitnessElement {
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_string"
@@ -244,7 +244,7 @@ impl_dlc_writeable!(WitnessElement, { (witness, vec) });
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -260,7 +260,7 @@ impl_dlc_writeable_enum!(NegotiationFields, (0, Single), (1, Disjoint);;;);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -274,7 +274,7 @@ impl_dlc_writeable!(SingleNegotiationFields, { (rounding_intervals, writeable) }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -288,7 +288,7 @@ impl_dlc_writeable!(DisjointNegotiationFields, { (negotiation_fields, vec) });
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -301,7 +301,7 @@ pub struct OfferDlc {
     /// Feature flags to be used for the offered contract.
     pub contract_flags: u8,
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -310,7 +310,7 @@ pub struct OfferDlc {
     /// The identifier of the chain on which the contract will be settled.
     pub chain_hash: [u8; 32],
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -410,7 +410,7 @@ impl_dlc_writeable!(OfferDlc, {
 /// party that they can safely provide signatures for their funding input.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -418,7 +418,7 @@ pub struct AcceptDlc {
     /// The version of the protocol used by the peer.
     pub protocol_version: u32,
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"
@@ -467,7 +467,7 @@ impl_dlc_writeable!(AcceptDlc, {
 /// party.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -475,7 +475,7 @@ pub struct SignDlc {
     /// The version of the protocol used by the peer.
     pub protocol_version: u32,
     #[cfg_attr(
-        feature = "serde",
+        feature = "use-serde",
         serde(
             serialize_with = "crate::serde_utils::serialize_hex",
             deserialize_with = "crate::serde_utils::deserialize_hex_array"

--- a/dlc-messages/src/oracle_msgs.rs
+++ b/dlc-messages/src/oracle_msgs.rs
@@ -10,7 +10,7 @@ use lightning::ln::wire::Type;
 use lightning::util::ser::{Readable, Writeable, Writer};
 use secp256k1_zkp::Verification;
 use secp256k1_zkp::{schnorr::Signature, Message, Secp256k1, XOnlyPublicKey};
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 use serde::{Deserialize, Serialize};
 
 /// The type of the announcement struct.
@@ -20,7 +20,7 @@ pub const ATTESTATION_TYPE: u16 = 55400;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -79,7 +79,7 @@ impl_dlc_writeable_enum!(
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -96,7 +96,7 @@ impl_dlc_writeable!(SingleOracleInfo, {
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -119,7 +119,7 @@ impl_dlc_writeable!(MultiOracleInfo, {
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -144,7 +144,7 @@ impl_dlc_writeable!(OracleParams, {
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -196,7 +196,7 @@ impl From<&OracleAnnouncement> for DlcOracleInfo {
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -244,7 +244,7 @@ impl_dlc_writeable!(OracleEvent, {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -260,7 +260,7 @@ impl_dlc_writeable_enum_as_tlv!(EventDescriptor, (55302, EnumEvent), (55306, Dig
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -276,7 +276,7 @@ impl_dlc_writeable!(EnumEventDescriptor, {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -305,6 +305,11 @@ impl_dlc_writeable!(DigitDecompositionEventDescriptor, {
 
 /// An attestation from an oracle providing signatures over an outcome value.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "use-serde",
+    derive(Serialize, Deserialize),
+    serde(rename_all = "camelCase")
+)]
 pub struct OracleAttestation {
     /// The public key of the oracle.
     pub oracle_public_key: XOnlyPublicKey,

--- a/dlc-messages/src/segmentation/mod.rs
+++ b/dlc-messages/src/segmentation/mod.rs
@@ -24,7 +24,7 @@ const MAX_SEGMENTS: usize = 1000;
 pub mod segment_reader;
 
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -50,7 +50,7 @@ impl Type for SegmentStart {
 }
 
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -17,7 +17,7 @@ extern crate core;
 extern crate miniscript;
 extern crate secp256k1_sys;
 pub extern crate secp256k1_zkp;
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 extern crate serde;
 
 use bitcoin::secp256k1::Scalar;
@@ -35,7 +35,7 @@ use secp256k1_zkp::{
     ecdsa::Signature, EcdsaAdaptorSignature, Message, PublicKey, Secp256k1, SecretKey,
     Verification, XOnlyPublicKey,
 };
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -84,7 +84,7 @@ macro_rules! checked_add {
 /// the initiator of the contract while accept party represents the party
 /// accepting the contract.
 #[derive(Eq, PartialEq, Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub struct Payout {
     /// Payout for the offering party
     pub offer: u64,
@@ -105,7 +105,7 @@ pub struct RangePayout {
 
 /// Representation of a payout for an enumeration outcome.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 pub struct EnumerationPayout {
     /// The outcome value (prior to hashing)
     pub outcome: String,
@@ -158,7 +158,7 @@ impl DlcTransactions {
 /// Contains info about a utxo used for funding a DLC contract
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -248,7 +248,7 @@ impl std::error::Error for Error {
 /// messages.
 #[derive(Clone, Debug)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "use-serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]


### PR DESCRIPTION
Replaces the feature `serde` to use the correct feature `use-serde`

Adds `use-serde` to `OracleAttestation`