### PR TITLE
Update bitcoin node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Cargo.lock
 **/*.profraw
 /coverage/
 /integration_coverage/
+.idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
   ### BITCOIND
   bitcoind:
-    image: ruimarinho/bitcoin-core:0.20.0
+    image: polarlightning/bitcoind:27.0
     container_name: bitcoin-node
     command: |
       -conf=/config/default.conf

--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -1,1 +1,2 @@
 dlc_sample*
+examples/contracts/sample_contract.json

--- a/sample/Readme.md
+++ b/sample/Readme.md
@@ -8,6 +8,8 @@ Example configurations and contract input are available in the [examples](./exam
 In order to use the [example contract](./examples/contracts/numerical_contract_input.json) you will need to update the `event_id`.
 Replace the part after `btcusd` with a UNIX timestamp in the future.
 
+Use the [helper script](../scripts/gen-sample-offer.sh) to create update the example contract 1 hour in the future. This replaces the `event_id` after `btcusd` with a UNIX timestamp 1 hour in the futre. Manually update the value for a longer time period.
+
 
 ## Quick run
 
@@ -24,13 +26,11 @@ In a different terminal:
 cargo run ./examples/configurations/bob.yml
 ```
 
-Update the [example contract](./examples/contracts/numerical_contract_input.json#L82) replacing the number after `btcusd` with a unix timestamp some time in the future (this will correspond to the contract maturity date).
-
 ### On chain DLC
 
 From the second instance (Bob), type:
 ```
-offercontract 02c84f8e151590e718d22e528c55f14c0042c66e68c3f793d7b3b8bf5ae630c648@127.0.0.1:9000 ./examples/contracts/numerical_contract_input.json
+offercontract 02c84f8e151590e718d22e528c55f14c0042c66e68c3f793d7b3b8bf5ae630c648@127.0.0.1:9000 ./examples/contracts/sample_contract.json
 ```
 Replacing the public key by the one that was displayed when starting the first instance.
 
@@ -67,7 +67,7 @@ Once the maturity of the contract is reached, typing `listcontracts` once more w
 
 From the second instance (Bob), type:
 ```
-offerchannel 02c84f8e151590e718d22e528c55f14c0042c66e68c3f793d7b3b8bf5ae630c648@127.0.0.1:9000 ./examples/contracts/numerical_contract_input.json
+offerchannel 02c84f8e151590e718d22e528c55f14c0042c66e68c3f793d7b3b8bf5ae630c648@127.0.0.1:9000 ./examples/contracts/sample_contract.json
 ```
 Replacing the public key by the one that was displayed when starting the first instance.
 

--- a/sample/Readme.md
+++ b/sample/Readme.md
@@ -8,7 +8,7 @@ Example configurations and contract input are available in the [examples](./exam
 In order to use the [example contract](./examples/contracts/numerical_contract_input.json) you will need to update the `event_id`.
 Replace the part after `btcusd` with a UNIX timestamp in the future.
 
-Use the [helper script](../scripts/gen-sample-offer.sh) to create update the example contract 1 hour in the future. This replaces the `event_id` after `btcusd` with a UNIX timestamp 1 hour in the futre. Manually update the value for a longer time period.
+Use the [helper script](../scripts/gen-sample-offer.sh) to create the example contract 1 hour in the future. This creates an `event_id` with a UNIX timestamp 1 hour in the future. Manually update the value for a longer time period.
 
 
 ## Quick run

--- a/scripts/create_wallets.sh
+++ b/scripts/create_wallets.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 bitcoincli=$(command -v bitcoin-cli)
-opts=( -rpcuser="testuser" -rpcpassword="lq6zequb-gYTdF2_ZEUtr8ywTXzLYtknzWU4nV8uVoo=" -regtest )
+opts=( -rpcuser="testuser" -rpcpassword="lq6zequb-gYTdF2_ZEUtr8ywTXzLYtknzWU4nV8uVoo=" -regtest -named)
 
-$bitcoincli "${opts[@]}" createwallet "alice" "false" "false"
-$bitcoincli "${opts[@]}" createwallet "bob" "false" "false"
+$bitcoincli "${opts[@]}" createwallet wallet_name="alice" descriptors="false"
+$bitcoincli "${opts[@]}" createwallet wallet_name="bob" descriptors="false"
 
 aliceAddress=$($bitcoincli "${opts[@]}" -rpcwallet=alice getnewaddress bec32)
 $bitcoincli "${opts[@]}" generatetoaddress 101 ${aliceAddress} &> /dev/null

--- a/scripts/gen-sample-offer.sh
+++ b/scripts/gen-sample-offer.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Calculate the Unix timestamp one hour from now
+DIR=$(git rev-parse --show-toplevel)
+
+current_timestamp=$(date +%s)
+future_timestamp=$((current_timestamp + 3600))
+# Read the JSON file and update the eventId field
+updated_json=$(jq --arg new_timestamp "$future_timestamp" '.contractInfos[0].oracles.eventId |= sub("\\d+$"; $new_timestamp)' ${DIR}/sample/examples/contracts/numerical_contract_input.json)
+
+# Output the updated JSON
+rm -f ${DIR}/sample/examples/contracts/sample_contract.json
+echo "$updated_json" > ${DIR}/sample/examples/contracts/sample_contract.json
+
+echo "Updated numerical contract has been saved"

--- a/testconfig/config/default.conf
+++ b/testconfig/config/default.conf
@@ -1,3 +1,5 @@
+deprecatedrpc=create_bdb
+
 [regtest]
 rpcallowip=0.0.0.0/0
 rpcbind=0.0.0.0


### PR DESCRIPTION
Adds a script `gen-sample-contract.sh` that creates a contract an hour in the future instead of manually editing.

Updates the bitcoin-core image to the latest. In doing this, the wallets have to be legacy for the RPC client to work. The RPC client will have to update to use descriptors in the `derive_contract_signer` method.
