### PR TITLE
fix: prealloc with making CETs

### DIFF
--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -583,7 +583,7 @@ pub fn create_cets(
     payouts: &[Payout],
     lock_time: u32,
 ) -> Vec<Transaction> {
-    let mut txs: Vec<Transaction> = Vec::new();
+    let mut txs: Vec<Transaction> = Vec::with_capacity(payouts.len());
     for payout in payouts {
         let offer_output = TxOut {
             value: payout.offer,


### PR DESCRIPTION
Most other vectors near this point in the library are pre-allocated, but this one wasn't. I observed a small (0.3%) perf increase for the existing benchmarks, when adapted to run under `iai-callgrind` instead of Criterion.