### PR TITLE
feat: single funded contracts

### DIFF
--- a/dlc-manager/src/channel_updater.rs
+++ b/dlc-manager/src/channel_updater.rs
@@ -92,9 +92,11 @@ where
     let id = get_new_temporary_id();
     let keys_id = signer_provider.derive_signer_key_id(true, id);
     let signer = signer_provider.derive_contract_signer(keys_id)?;
+    let total_collateral = contract.accept_collateral + contract.offer_collateral;
     let (offer_params, funding_inputs_info) = crate::utils::get_party_params(
         secp,
         contract.offer_collateral,
+        total_collateral,
         contract.fee_rate,
         wallet,
         &signer,
@@ -163,6 +165,7 @@ where
     let (accept_params, funding_inputs) = crate::utils::get_party_params(
         secp,
         total_collateral - offered_contract.offer_params.collateral,
+        total_collateral,
         offered_contract.fee_rate_per_vb,
         wallet,
         &signer,

--- a/dlc-manager/src/contract/contract_input.rs
+++ b/dlc-manager/src/contract/contract_input.rs
@@ -8,6 +8,8 @@ use secp256k1_zkp::XOnlyPublicKey;
 #[cfg(feature = "use-serde")]
 use serde::{Deserialize, Serialize};
 
+const DUST_LIMIT: Amount = Amount::from_sat(1000);
+
 /// Oracle information required for the initial creation of a contract.
 #[derive(Debug, Clone)]
 #[cfg_attr(
@@ -87,6 +89,12 @@ pub struct ContractInput {
 impl ContractInput {
     /// Validate the contract input parameters
     pub fn validate(&self) -> Result<(), Error> {
+        if self.offer_collateral < DUST_LIMIT {
+            return Err(Error::InvalidParameters(
+                "Offer collateral must be greater than dust limit.".to_string(),
+            ));
+        }
+
         if self.contract_infos.is_empty() {
             return Err(Error::InvalidParameters(
                 "Need at least one contract info".to_string(),

--- a/dlc-manager/src/contract_updater.rs
+++ b/dlc-manager/src/contract_updater.rs
@@ -50,9 +50,11 @@ where
     let id = crate::utils::get_new_temporary_id();
     let keys_id = signer_provider.derive_signer_key_id(true, id);
     let signer = signer_provider.derive_contract_signer(keys_id)?;
+    let total_collateral = contract_input.accept_collateral + contract_input.offer_collateral;
     let (party_params, funding_inputs_info) = crate::utils::get_party_params(
         secp,
         contract_input.offer_collateral,
+        total_collateral,
         contract_input.fee_rate,
         wallet,
         &signer,
@@ -96,6 +98,7 @@ where
     let (accept_params, funding_inputs) = crate::utils::get_party_params(
         secp,
         total_collateral - offered_contract.offer_params.collateral,
+        total_collateral,
         offered_contract.fee_rate_per_vb,
         wallet,
         &signer,

--- a/dlc-manager/src/utils.rs
+++ b/dlc-manager/src/utils.rs
@@ -2,7 +2,7 @@
 use std::ops::Deref;
 
 use bitcoin::{consensus::Encodable, Amount, Txid};
-use dlc::{PartyParams, TxInputInfo};
+use dlc::{util::get_common_fee, PartyParams, TxInputInfo};
 use dlc_messages::{
     oracle_msgs::{OracleAnnouncement, OracleAttestation},
     FundingInput,
@@ -92,6 +92,7 @@ pub(crate) fn compute_id(
 pub(crate) fn get_party_params<W: Deref, B: Deref, X: ContractSigner, C: Signing>(
     secp: &Secp256k1<C>,
     own_collateral: Amount,
+    total_collateral: Amount,
     fee_rate: u64,
     wallet: &W,
     signer: &X,
@@ -110,9 +111,8 @@ where
     let change_spk = change_addr.script_pubkey();
     let change_serial_id = get_new_serial_id();
 
-    // Add base cost of fund tx + CET / 2 and a CET output to the collateral.
     let appr_required_amount =
-        own_collateral + get_half_common_fee(fee_rate)? + dlc::util::weight_to_fee(124, fee_rate)?;
+        get_approximate_required_amount(total_collateral, own_collateral, fee_rate)?;
     let utxos = wallet.get_utxos_for_amount(appr_required_amount, fee_rate, true)?;
 
     let mut funding_inputs: Vec<FundingInput> = Vec::new();
@@ -151,6 +151,37 @@ where
     };
 
     Ok((party_params, funding_inputs))
+}
+
+// If own_collateral is zero, appr_required_amount is zero.
+// If own_collateral is equal to total_collateral, appr_required_amount is the common fee.
+// Otherwise, appr_required_amount is the half common fee.
+// Add base cost of fund tx + CET / 2 and a CET output to the collateral.
+fn get_approximate_required_amount(
+    total_collateral: Amount,
+    own_collateral: Amount,
+    fee_rate: u64,
+) -> Result<Amount, Error> {
+    // defaults to a p2wpkh address for CET execution
+    // 20 bytes pubkey hash + 2 bytes opcodes + 9 bytes base output size = 31 bytes * 4 = 124 bytes
+    // TODO: handle different address types for CET execution (multisig, p2wsh, p2tr, etc.)
+    const ASSUME_P2WPKH_WEIGHT: usize = 124;
+
+    let appr_required_amount = if own_collateral == Amount::ZERO {
+        // No collateral = no fees
+        Amount::ZERO
+    } else if own_collateral == total_collateral {
+        // Full collateral = full fees
+        own_collateral
+            + get_common_fee(fee_rate)?
+            + dlc::util::weight_to_fee(ASSUME_P2WPKH_WEIGHT, fee_rate)?
+    } else {
+        // Partial collateral = split fees
+        own_collateral
+            + get_half_common_fee(fee_rate)?
+            + dlc::util::weight_to_fee(ASSUME_P2WPKH_WEIGHT, fee_rate)?
+    };
+    Ok(appr_required_amount)
 }
 
 pub(crate) fn get_party_base_points<C: Signing, SP: Deref>(
@@ -228,6 +259,37 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn get_appr_required_amount_single_funded_dlc() {
+        let total_collateral = Amount::ONE_BTC;
+        let own_collateral = Amount::ONE_BTC;
+        let fee_rate = 2;
+        let appr_required_amount =
+            get_approximate_required_amount(total_collateral, own_collateral, fee_rate).unwrap();
+        let expected_amount = Amount::ONE_BTC + Amount::from_sat(420);
+        assert_eq!(appr_required_amount, expected_amount);
+    }
+
+    #[test]
+    fn get_appr_required_amount_unfunded_dlc() {
+        let total_collateral = Amount::ONE_BTC;
+        let own_collateral = Amount::ZERO;
+        let fee_rate = 2;
+        let appr_required_amount =
+            get_approximate_required_amount(total_collateral, own_collateral, fee_rate).unwrap();
+        assert_eq!(appr_required_amount, Amount::ZERO);
+    }
+
+    #[test]
+    fn get_appr_required_amount_dual_funded_dlc() {
+        let total_collateral = Amount::ONE_BTC;
+        let own_collateral = Amount::from_sat(50_000_000);
+        let fee_rate = 2;
+        let appr_required_amount =
+            get_approximate_required_amount(total_collateral, own_collateral, fee_rate).unwrap();
+        assert_eq!(appr_required_amount, Amount::from_sat(50_000_000 + 241));
+    }
 
     #[test]
     fn id_computation_test() {

--- a/dlc-manager/tests/manager_execution_tests.rs
+++ b/dlc-manager/tests/manager_execution_tests.rs
@@ -510,6 +510,16 @@ fn two_of_five_oracle_numerical_diff_nb_digits_max_value_manual_test() {
     numerical_common_diff_nb_digits(5, 2, None, true, true);
 }
 
+#[test]
+#[ignore]
+fn single_funded_dlc_test() {
+    manager_execution_test(
+        get_single_funded_test_params(1, 1, None),
+        TestPath::Close,
+        false,
+    );
+}
+
 fn alter_adaptor_sig(input: &mut CetAdaptorSignatures) {
     let sig_index = thread_rng().next_u32() as usize % input.ecdsa_adaptor_signatures.len();
 

--- a/dlc-manager/tests/test_utils.rs
+++ b/dlc-manager/tests/test_utils.rs
@@ -300,6 +300,35 @@ pub fn get_enum_test_params(
     }
 }
 
+pub fn get_single_funded_test_params(
+    nb_oracles: usize,
+    threshold: usize,
+    oracles: Option<Vec<MockOracle>>,
+) -> TestParams {
+    let oracles = oracles.unwrap_or_else(|| get_enum_oracles(nb_oracles, threshold));
+    let contract_descriptor = get_enum_contract_descriptor();
+    let contract_info = ContractInputInfo {
+        contract_descriptor,
+        oracles: OracleInput {
+            public_keys: oracles.iter().map(|x| x.get_public_key()).collect(),
+            event_id: EVENT_ID.to_owned(),
+            threshold: 1,
+        },
+    };
+
+    let contract_input = ContractInput {
+        offer_collateral: TOTAL_COLLATERAL,
+        accept_collateral: Amount::ZERO,
+        fee_rate: 2,
+        contract_infos: vec![contract_info],
+    };
+
+    TestParams {
+        oracles,
+        contract_input,
+    }
+}
+
 pub fn get_polynomial_payout_curve_pieces(min_nb_digits: usize) -> Vec<PayoutFunctionPiece> {
     vec![
         PayoutFunctionPiece::PolynomialPayoutCurvePiece(

--- a/dlc-messages/src/channel.rs
+++ b/dlc-messages/src/channel.rs
@@ -573,7 +573,6 @@ impl_dlc_writeable!(CollaborativeCloseOffer, {
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
-
 /// Message used to reject an received offer.
 pub struct Reject {
     #[cfg_attr(

--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -293,10 +293,21 @@ impl PartyParams {
     /// plus the required fees, an error is returned.
     pub(crate) fn get_change_output_and_fees(
         &self,
+        total_collateral: Amount,
         fee_rate_per_vb: u64,
         extra_fee: Amount,
     ) -> Result<(TxOut, Amount, Amount), Error> {
         let mut inputs_weight: usize = 0;
+
+        // first check if a party does not need to fund the contract if so, then it is zero
+        if self.collateral == Amount::ZERO {
+            // We use a zero value output to indicate that the party does not need to fund the contract
+            let change_output = TxOut {
+                value: Amount::ZERO,
+                script_pubkey: self.change_script_pubkey.clone(),
+            };
+            return Ok((change_output, Amount::ZERO, Amount::ZERO));
+        }
 
         for w in &self.inputs {
             let script_weight = util::redeem_script_to_script_sig(&w.redeem_script)
@@ -316,9 +327,14 @@ impl PartyParams {
         // Change size is scaled by 4 from vBytes to weight units
         let change_weight = change_size.checked_mul(4).ok_or(Error::InvalidArgument)?;
 
-        // Base weight (nLocktime, nVersion, ...) is distributed among parties
+        // If the party is funding the whole contract, then the base weight is the full base weight
+        // otherwise, the base weight (nLocktime, nVersion, ...) is distributed among parties
         // independently of inputs contributed
-        let this_party_fund_base_weight = FUND_TX_BASE_WEIGHT / 2;
+        let this_party_fund_base_weight = if self.collateral == total_collateral {
+            FUND_TX_BASE_WEIGHT
+        } else {
+            FUND_TX_BASE_WEIGHT / 2
+        };
 
         let total_fund_weight = checked_add!(
             this_party_fund_base_weight,
@@ -328,9 +344,14 @@ impl PartyParams {
         )?;
         let fund_fee = util::weight_to_fee(total_fund_weight, fee_rate_per_vb)?;
 
-        // Base weight (nLocktime, nVersion, funding input ...) is distributed
+        // If the party is funding the whole contract, then the base weight is the full base weight
+        // otherwise, the base weight (nLocktime, nVersion, funding input ...) is distributed
         // among parties independently of output types
-        let this_party_cet_base_weight = CET_BASE_WEIGHT / 2;
+        let this_party_cet_base_weight = if self.collateral == total_collateral {
+            CET_BASE_WEIGHT
+        } else {
+            CET_BASE_WEIGHT / 2
+        };
 
         // size of the payout script pubkey scaled by 4 from vBytes to weight units
         let output_spk_weight = self
@@ -340,6 +361,7 @@ impl PartyParams {
             .ok_or(Error::InvalidArgument)?;
         let total_cet_weight = checked_add!(this_party_cet_base_weight, output_spk_weight)?;
         let cet_or_refund_fee = util::weight_to_fee(total_cet_weight, fee_rate_per_vb)?;
+
         let required_input_funds =
             checked_add!(self.collateral, fund_fee, cet_or_refund_fee, extra_fee)?;
         if self.input_amount < required_input_funds {
@@ -427,9 +449,9 @@ pub(crate) fn create_fund_transaction_with_fees(
     let total_collateral = checked_add!(offer_params.collateral, accept_params.collateral)?;
 
     let (offer_change_output, offer_fund_fee, offer_cet_fee) =
-        offer_params.get_change_output_and_fees(fee_rate_per_vb, extra_fee)?;
+        offer_params.get_change_output_and_fees(total_collateral, fee_rate_per_vb, extra_fee)?;
     let (accept_change_output, accept_fund_fee, accept_cet_fee) =
-        accept_params.get_change_output_and_fees(fee_rate_per_vb, extra_fee)?;
+        accept_params.get_change_output_and_fees(total_collateral, fee_rate_per_vb, extra_fee)?;
 
     let fund_output_value = checked_add!(offer_params.input_amount, accept_params.input_amount)?
         - offer_change_output.value
@@ -1267,15 +1289,56 @@ mod tests {
     }
 
     #[test]
+    fn get_change_output_and_fees_no_inputs_no_funding() {
+        let (party_params, _) = get_party_params(Amount::ZERO, Amount::ZERO, None);
+
+        let total_collateral = Amount::ONE_BTC;
+
+        let (change_out, fund_fee, cet_fee) = party_params
+            .get_change_output_and_fees(total_collateral, 4, Amount::ZERO)
+            .unwrap();
+
+        assert_eq!(change_out.value, Amount::ZERO);
+        assert_eq!(fund_fee, Amount::ZERO);
+        assert_eq!(cet_fee, Amount::ZERO);
+    }
+
+    #[test]
+    fn get_change_output_and_fees_single_funded_vs_dual_funded() {
+        let (party_params_single_funded, _) =
+            get_party_params(Amount::from_sat(150_000_000), Amount::ONE_BTC, None);
+
+        let total_collateral = Amount::ONE_BTC;
+
+        let (change_out_single_funded, fund_fee_single_funded, cet_fee_single_funded) =
+            party_params_single_funded
+                .get_change_output_and_fees(total_collateral, 4, Amount::ZERO)
+                .unwrap();
+
+        let (party_params_dual_funded, _) =
+            get_party_params(Amount::from_sat(150_000_000), Amount::ONE_BTC, None);
+        let total_collateral = Amount::ONE_BTC + Amount::ONE_BTC;
+
+        let (change_out_dual_funded, fund_fee_dual_funded, cet_fee_dual_funded) =
+            party_params_dual_funded
+                .get_change_output_and_fees(total_collateral, 4, Amount::ZERO)
+                .unwrap();
+
+        assert!(change_out_single_funded.value < change_out_dual_funded.value);
+        assert!(fund_fee_single_funded > fund_fee_dual_funded);
+        assert!(cet_fee_single_funded > cet_fee_dual_funded);
+    }
+
+    #[test]
     fn get_change_output_and_fees_enough_funds() {
         // Arrange
         let (party_params, _) =
             get_party_params(Amount::from_sat(100000), Amount::from_sat(10000), None);
 
         // Act
-
+        let total_collateral = Amount::from_sat(100001);
         let (change_out, fund_fee, cet_fee) = party_params
-            .get_change_output_and_fees(4, Amount::ZERO)
+            .get_change_output_and_fees(total_collateral, 4, Amount::ZERO)
             .unwrap();
 
         // Assert
@@ -1290,8 +1353,9 @@ mod tests {
         let (party_params, _) =
             get_party_params(Amount::from_sat(100000), Amount::from_sat(100000), None);
 
+        let total_collateral = Amount::from_sat(100001);
         // Act
-        let res = party_params.get_change_output_and_fees(4, Amount::ZERO);
+        let res = party_params.get_change_output_and_fees(total_collateral, 4, Amount::ZERO);
 
         // Assert
         assert!(res.is_err());

--- a/mocks/src/memory_storage_provider.rs
+++ b/mocks/src/memory_storage_provider.rs
@@ -61,13 +61,13 @@ impl MemoryStorage {
         let mut contracts_saved = self.contracts_saved.lock().unwrap();
         let mut tmp = None;
         std::mem::swap(&mut tmp, &mut *contracts_saved);
-        std::mem::swap(&mut *contracts, &mut tmp.unwrap());
+        *contracts = tmp.unwrap();
 
         let mut channels = self.channels.write().unwrap();
         let mut channels_saved = self.channels_saved.lock().unwrap();
         let mut tmp = None;
         std::mem::swap(&mut tmp, &mut *channels_saved);
-        std::mem::swap(&mut *channels, &mut tmp.unwrap());
+        *channels = tmp.unwrap();
     }
 }
 

--- a/sample/src/hex_utils.rs
+++ b/sample/src/hex_utils.rs
@@ -43,8 +43,5 @@ pub fn hex_str(value: &[u8]) -> String {
 
 pub fn to_compressed_pubkey(hex: &str) -> Option<PublicKey> {
     let data = to_vec(&hex[0..33 * 2])?;
-    match PublicKey::from_slice(&data) {
-        Ok(pk) => Some(pk),
-        Err(_) => None,
-    }
+    PublicKey::from_slice(&data).ok()
 }


### PR DESCRIPTION
This PR implements single-funded DLCs where only one party provides collateral and covers all transaction fees, while the other party contributes no inputs or fees.

## Problem

The current implementation requires both parties to split transaction fees (funding, CET, and refund), even when one party provides zero collateral. This prevents true single-funded DLCs where the acceptor contributes nothing.

## Solution

Fee calculation is now dynamic based on collateral contribution:

- **Zero collateral**: Party pays no fees, provides no inputs
- **Full collateral**: Party pays all fees (single-funded)  
- **Partial collateral**: Fees split between parties (existing dual-funded behavior)

## Additional Changes

**Contract Input Validation**: Added dust limit checks per DLC specifications - offer collateral and total collateral must be above dust limit when non-zero. [Follow spec for offer collateral](https://github.com/discreetlogcontracts/dlcspecs/blob/9cd9148938c616690c79d99ec6f330e213c246c5/Protocol.md?plain=1#L141)

**Code Quality**: Fixed clippy warnings throughout the codebase.

## Backward Compatibility

Existing dual-funded DLCs work unchanged. API changes are additive with no breaking changes to existing functionality.